### PR TITLE
Modify the accuracy of the 32K clock.

### DIFF
--- a/examples/mesh-light/src/main.c
+++ b/examples/mesh-light/src/main.c
@@ -113,6 +113,8 @@ int app_main()
     // Otherwise, below line should be kept commented out.
     // platform_set_rf_clk_source(0);
     
+    platform_config(PLATFORM_CFG_32K_CLK_ACC, 200);
+    
     setup_peripherals();
 
     // setup putc handle


### PR DESCRIPTION
As slave, Improve the connection stability with Meizu mobile phones and OPPO mobile phones by changing local SCA.