### PR TITLE
Force address to static type.

### DIFF
--- a/examples/mesh-light/src/mesh_port_low_level_init.c
+++ b/examples/mesh-light/src/mesh_port_low_level_init.c
@@ -233,6 +233,7 @@ void mesh_platform_config(bt_mesh_config_t type, void *data, uint32_t data_len){
 #ifdef MESH_GATT_ADV_ADDR_USE_FLASH
             bd_addr_t addr;
             mesh_gatt_addr_generate_and_get(addr);
+            mesh_set_addr_static((uint8_t *)addr);
             mesh_gatt_adv_addr_set(addr);
 #else
             mesh_gatt_adv_addr_set((uint8_t *) data);
@@ -243,6 +244,7 @@ void mesh_platform_config(bt_mesh_config_t type, void *data, uint32_t data_len){
 #ifdef MESH_BEACON_ADV_ADDR_USE_FLASH
             bd_addr_t addr;
             mesh_beacon_addr_generate_and_get(addr);
+            mesh_set_addr_static((uint8_t *)addr);
             mesh_beacon_adv_addr_set(addr);
 #else
             mesh_beacon_adv_addr_set((uint8_t *) data);
@@ -456,4 +458,11 @@ void mesh_elems_and_models_ll_init(const bt_mesh_comp_t *a_comp){
             }
         }
     }
+}
+
+/* Change address to static, ref: https://ingchips.github.io/application-notes/pg_ble_stack_cn/ch-overview.html#ch-overview-ble-addr */
+void mesh_set_addr_static(uint8_t * addr)
+{
+    if(addr != NULL)
+        addr[0] |= 0xC0;
 }

--- a/examples/mesh-light/src/mesh_port_low_level_init.h
+++ b/examples/mesh-light/src/mesh_port_low_level_init.h
@@ -19,7 +19,7 @@ void mesh_elems_and_models_ll_init(const bt_mesh_comp_t *a_comp);
 void mesh_prov_ll_init(const bt_mesh_prov_t *prov);
 void mesh_platform_config(bt_mesh_config_t type, void *data, uint32_t data_len);
 void mesh_platform_adv_params_init(void);
-
+void mesh_set_addr_static(uint8_t * addr);
 
 #endif
 

--- a/examples/mesh-light/src/profile.c
+++ b/examples/mesh-light/src/profile.c
@@ -223,6 +223,8 @@ void mesh_platform_init(void){
     const bd_addr_t addr_gatt_adv    = {0xd5, 0x33, 0xa3, 0x17, 0x2f, 0xFC};
     const bd_addr_t addr_beacon_adv  = {0xd0, 0x2a, 0x4e, 0x19, 0x28, 0xFC};
 
+    mesh_set_addr_static((uint8_t *)addr_gatt_adv);
+    mesh_set_addr_static((uint8_t *)addr_beacon_adv);
     mesh_platform_config(MESH_CFG_NAME, (uint8_t *)mesh_name, strlen(mesh_name));
     mesh_platform_config(MESH_CFG_GATT_ADV_ADDR, (uint8_t *)addr_gatt_adv, sizeof(bd_addr_t));
     mesh_platform_config(MESH_CFG_BEACON_ADV_ADDR, (uint8_t *)addr_beacon_adv, sizeof(bd_addr_t));


### PR DESCRIPTION
Prevent the use of illegal address, resulting in the iPhone cannot search, such as A5:XX:XX:XX:XX:XX is illegal. ref: https://ingchips.github.io/application-notes/pg_ble_stack_cn/ch-overview.html#ch-overview-ble-addr