### PR TITLE
bugfix that ADC_GetVol returns VREFP when ADC data >= it's maximum.

### DIFF
--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -420,8 +420,8 @@ float ADC_GetVol(const uint16_t data)
 {
     if (!ADC_adcCal.cb || !ADC_adcCal.vref_P)
         return 0.f;
-    if (data > ADC_MK_MASK(14))
-        return 0.f;
+    if (data >= ADC_MK_MASK(14))
+        return ADC_adcCal.vref_P;
     return ADC_adcCal.cb(data);
 }
 
@@ -531,8 +531,7 @@ void ADC_ftInit(void)
     ftCalPara.p_adcCali = (const uint16_t *)flash_get_adc_calib_data();
     if (ret || !p_factoryCali || !ftCalPara.p_adcCali)
         ftCalPara.readFlg = 1;
-    ftCali = malloc(sizeof(SADC_ftCali_t));
-    memset(ftCali, 0, sizeof(SADC_ftCali_t));
+    ftCali = calloc(0, sizeof(SADC_ftCali_t));
 
     if (ftCalPara.readFlg)
         ftCalPara.flg = read_flash_security(0x1170);

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -531,7 +531,7 @@ void ADC_ftInit(void)
     ftCalPara.p_adcCali = (const uint16_t *)flash_get_adc_calib_data();
     if (ret || !p_factoryCali || !ftCalPara.p_adcCali)
         ftCalPara.readFlg = 1;
-    ftCali = calloc(0, sizeof(SADC_ftCali_t));
+    ftCali = calloc(1, sizeof(SADC_ftCali_t));
 
     if (ftCalPara.readFlg)
         ftCalPara.flg = read_flash_security(0x1170);

--- a/src/FWlib/peripheral_ssp.c
+++ b/src/FWlib/peripheral_ssp.c
@@ -281,7 +281,6 @@ void apSSP_Initialize (SSP_TypeDef *SPI_BASE)
 
 void apSSP_DeviceParametersSet(SSP_TypeDef *SPI_BASE, apSSP_sDeviceControlBlock *pParam)
 {
-    #define TRANSCNT_CHECK(c)   (c) &= (((1) << (0x9)) - (1)); (c) += ((c) ? (0) : (1));
 
     apSSP_Initialize(SPI_BASE);
 
@@ -294,8 +293,6 @@ void apSSP_DeviceParametersSet(SSP_TypeDef *SPI_BASE, apSSP_sDeviceControlBlock 
                           pParam->eMasterSlaveMode  << bsSPI_TRANSFMT_SLVMODE |
                           pParam->eAddrLen          << bsSPI_TRANSFMT_ADDRLEN);
 
-    TRANSCNT_CHECK(pParam->eWriteTransCnt)
-    TRANSCNT_CHECK(pParam->eReadTransCnt)
     SPI_BASE->TransCtrl = (pParam->eReadWriteMode         << bsSPI_TRANSCTRL_TRANSMODE |
                           pParam->eQuadMode               << bsSPI_TRANSCTRL_DUALQUAD |
                           ((pParam->eWriteTransCnt)-1)    << bsSPI_TRANSCTRL_WRTRANCNT |

--- a/src/FWlib/peripheral_ssp.c
+++ b/src/FWlib/peripheral_ssp.c
@@ -281,6 +281,7 @@ void apSSP_Initialize (SSP_TypeDef *SPI_BASE)
 
 void apSSP_DeviceParametersSet(SSP_TypeDef *SPI_BASE, apSSP_sDeviceControlBlock *pParam)
 {
+    #define TRANSCNT_CHECK(c)   (c) &= (((1) << (0x9)) - (1)); (c) += ((c) ? (0) : (1));
 
     apSSP_Initialize(SPI_BASE);
 
@@ -293,6 +294,8 @@ void apSSP_DeviceParametersSet(SSP_TypeDef *SPI_BASE, apSSP_sDeviceControlBlock 
                           pParam->eMasterSlaveMode  << bsSPI_TRANSFMT_SLVMODE |
                           pParam->eAddrLen          << bsSPI_TRANSFMT_ADDRLEN);
 
+    TRANSCNT_CHECK(pParam->eWriteTransCnt)
+    TRANSCNT_CHECK(pParam->eReadTransCnt)
     SPI_BASE->TransCtrl = (pParam->eReadWriteMode         << bsSPI_TRANSCTRL_TRANSMODE |
                           pParam->eQuadMode               << bsSPI_TRANSCTRL_DUALQUAD |
                           ((pParam->eWriteTransCnt)-1)    << bsSPI_TRANSCTRL_WRTRANCNT |


### PR DESCRIPTION
bugfix that ADC_GetVol returns VREFP when ADC data >= it's maximum.