### PR TITLE
ADC_GetData fix

### DIFF
--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -404,7 +404,7 @@ uint16_t ADC_GetData(const uint32_t data)
                 chPara = &(ftCali->chParaSinNoPga[ch]);
         }
     }
-    if (chPara)
+    if (chPara->Coseq && chPara->k)
         return ftCali->f(chPara, data & ADC_MK_MASK(14));
     return (data & ADC_MK_MASK(14));
 }

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -404,7 +404,7 @@ uint16_t ADC_GetData(const uint32_t data)
                 chPara = &(ftCali->chParaSinNoPga[ch]);
         }
     }
-    if (chPara->Coseq && chPara->k)
+    if (chPara && chPara->Coseq && chPara->k)
         return ftCali->f(chPara, data & ADC_MK_MASK(14));
     return (data & ADC_MK_MASK(14));
 }


### PR DESCRIPTION
ADC_GetData fix that returns raw adc data when coseq or k equals 0.