### PR TITLE
optimize kv_impl

### DIFF
--- a/examples/hid_keyboard/src/kv_impl.c
+++ b/examples/hid_keyboard/src/kv_impl.c
@@ -72,7 +72,7 @@ static int kv_flash_repair(uint32_t start, uint32_t end)
         uint32_t next = next_item(item);
         if (next >= end)
             break;
-        start = end;
+        start = next;
         item = (struct kv_item *)start;
     }
 


### PR DESCRIPTION
Fix an issue where FLASH would be erased every time it was started when having more than two KV pairs in the FLASH.