### PR TITLE
modify uart initialization of  [I/O-Over-BLE-Peripheral] example

### DIFF
--- a/examples/io_over_ble_mas/src/io_interf.c
+++ b/examples/io_over_ble_mas/src/io_interf.c
@@ -136,6 +136,7 @@ static void config_uart(uint32_t freq, uint32_t baud)
 
 void io_interf_setup_peripherals()
 {
+    SYSCTRL_ClearClkGateMulti(1 << SYSCTRL_ClkGate_APB_PinCtrl);
     SYSCTRL_ClearClkGateMulti((1 << SYSCTRL_ClkGate_APB_UART1));
     config_uart(OSC_CLK_FREQ, 921600);
 


### PR DESCRIPTION
Fix problem of UART can't work after  [I/O-Over-BLE-Peripheral]  example switch to ing916.