### PR TITLE
update peripheral_ssp.c .h Support three-wire mode

### DIFF
--- a/src/FWlib/peripheral_ssp.c
+++ b/src/FWlib/peripheral_ssp.c
@@ -291,7 +291,8 @@ void apSSP_DeviceParametersSet(SSP_TypeDef *SPI_BASE, apSSP_sDeviceControlBlock 
                           pParam->eLsbMsbOrder      << bsSPI_TRANSFMT_LSB |
                           pParam->eDataSize         << bsSPI_TRANSFMT_DATALEN |
                           pParam->eMasterSlaveMode  << bsSPI_TRANSFMT_SLVMODE |
-                          pParam->eAddrLen          << bsSPI_TRANSFMT_ADDRLEN);
+                          pParam->eAddrLen          << bsSPI_TRANSFMT_ADDRLEN |
+                          pParam->eMOSI_Dir         << bsSPI_TRANSFMT_MOSIBIDIR );
 
     SPI_BASE->TransCtrl = (pParam->eReadWriteMode         << bsSPI_TRANSCTRL_TRANSMODE |
                           pParam->eQuadMode               << bsSPI_TRANSCTRL_DUALQUAD |

--- a/src/FWlib/peripheral_ssp.h
+++ b/src/FWlib/peripheral_ssp.h
@@ -340,9 +340,9 @@ typedef enum
   SPI_ADDRFMT_QUAD_MODE = 1
 }SPI_TransCtrl_AddrFmt_e;
 
-/* SPI_MOSI_UNI_DIR_MODE: This register sets the MOSI pin of the SPI as the normal mode
-   SPI_MOSI_BI_DIR_MODE: This register sets the MOSI pin of SPI as a bidirectional mode, 
-    and SPI can use a three-wire transmission mode */
+/* SPI_MOSI_UNI_DIR_MODE: This mode sets the MOSI pin of the SPI as the normal mode.
+   SPI_MOSI_BI_DIR_MODE: This mode sets the MOSI pin of SPI as a bidirectional mode.
+   This bi-directional signal replaces the two uni-directional data signals, MOSI and MISO. */
 typedef enum
 {
     SPI_MOSI_UNI_DIR_MODE = 0,

--- a/src/FWlib/peripheral_ssp.h
+++ b/src/FWlib/peripheral_ssp.h
@@ -340,6 +340,15 @@ typedef enum
   SPI_ADDRFMT_QUAD_MODE = 1
 }SPI_TransCtrl_AddrFmt_e;
 
+/* SPI_MOSI_UNI_DIR_MODE: This register sets the MOSI pin of the SPI as the normal mode
+   SPI_MOSI_BI_DIR_MODE: This register sets the MOSI pin of SPI as a bidirectional mode, 
+    and SPI can use a three-wire transmission mode */
+typedef enum
+{
+    SPI_MOSI_UNI_DIR_MODE = 0,
+    SPI_MOSI_BI_DIR_MODE = 1
+}SPI_MOSI_Dir_Set_e;
+
 /* ----------------------------------------------------------
  * Description:
  * Bit shifts and widths for Control Register "Ctrl"
@@ -377,7 +386,7 @@ typedef uint8_t SPI_ControlTxThres;
  * Description:
  * Bit shifts and widths for Int Register "IntrEn"
  */
- 
+
 /* Enable the SPI Receive FIFO Threshold interrupt. Control whether interrupts are triggered when the valid entries are greater than or equal to the RX FIFO
 threshold. */
 #define bsSPI_INTREN_RXFIFOINTEN    2
@@ -565,6 +574,8 @@ typedef struct apSSP_xDeviceControlBlock
   /* Data-only mode (slave mode only) 0x0: Disable the data-only mode 0x1: Enable the data-only mode */
   SPI_TransCtrl_SlvDataOnly_e  SlaveDataOnly;
   SPI_TransFmt_AddrLen_e       eAddrLen;
+  /* 0x0  MOSI is uni-directional signal in regular mode. 0x1: MOSI is bi-directional signal in regular mode. */
+  SPI_MOSI_Dir_Set_e            eMOSI_Dir;
 } apSSP_sDeviceControlBlock;
 
 /**


### PR DESCRIPTION
Updated ssp content in FWlib, now you can use three-wire SPI for data communication by setting the mode selection in the initialization structure.