### PR TITLE
SYSCTRL_Init add the 32k clock crossover factor for initialization

### DIFF
--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -1143,6 +1143,7 @@ int SYSCTRL_Init(void)
     if (!p) return 1;
 
     set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x8), p->band_gap, 7, 4);
+    set_reg_bits(APB_SYSCTRL->CguCfg + 7, 750, 12, 20);
 
     for (i = 0; i < sizeof(p->vaon) / sizeof(p->vaon[0]); i++)
     {


### PR DESCRIPTION
916外设使用32k外部时钟时，32K时钟来自于24M时钟的750分频，寄存器分频默认值为1000硬件实际使用默认值为750，分频值不一致导致SDK读取外设当前时钟和实际不一致，在SYSCTRL_Init()函数中增加更新分频默认值使得默认为750分频，保证读取和实际时钟的一致性。