### PR TITLE
1、fix bsp_usb recive bug.

### DIFF
--- a/src/BSP/bsp_usb.h
+++ b/src/BSP/bsp_usb.h
@@ -149,6 +149,7 @@ typedef struct
 extern void bsp_usb_init(void);
 extern void bsp_usb_disable(void);
 extern void bsp_usb_device_remote_wakeup(void);
+extern uint32_t bsp_usb_send_data(const uint8_t data[], uint32_t len);
 
 #ifdef FEATURE_DISCONN_DETECT
 void bsp_usb_device_disconn_timeout(void);


### PR DESCRIPTION
1、bsp_usb.c 中 USB_EVENT_EP_DATA_TRANSFER->USB_CALLBACK_TYPE_RECEIVE_END，接收数据时调用API不对，导致接收一次数据后无法再继续接收数据；
2、bsp_usb.c 中添加发送数据相关API。