### PR TITLE
fix bsp_usb recive bug.

### DIFF
--- a/src/BSP/bsp_usb.c
+++ b/src/BSP/bsp_usb.c
@@ -240,8 +240,9 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
           {
             uint32_t i;
             platform_printf("(%d)data: ",event->data.ep);for(i=0;i<10;i++){platform_printf(" 0x%x ",DataRecvBuf[i]);}platform_printf("\n");
+            
+            status |= USB_RecvData(ConfigDescriptor.endpoint[EP_OUT-1].ep, DataRecvBuf, ConfigDescriptor.endpoint[EP_OUT-1].mps, 0);
 
-            memset(DataSendBuf, 0x33, sizeof(DataSendBuf));
             status |= USB_SendData(ConfigDescriptor.endpoint[EP_IN-1].ep, DataRecvBuf, ConfigDescriptor.endpoint[EP_IN-1].mps, 0);
           }
         }break;
@@ -249,7 +250,7 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
         {
           if(event->data.ep == EP_IN)
           {
-            status |= USB_RecvData(ConfigDescriptor.endpoint[EP_OUT-1].ep, DataRecvBuf, ConfigDescriptor.endpoint[EP_OUT-1].mps, 0);
+            platform_printf("[USB] usb send data complete.\n");
           }
         }break;
         default:
@@ -283,6 +284,22 @@ void bsp_usb_init(void)
   USB_InitConfig(&config);
 }
 
+uint32_t bsp_usb_send_data(const uint8_t data[], uint32_t len)
+{
+  uint32_t size = 0, status, ret = 0;
+  size = (len >= EP_X_MPS_BYTES) ? EP_X_MPS_BYTES : len;
+  
+  memcpy(DataSendBuf, data, size);
+  status = USB_SendData(ConfigDescriptor.endpoint[EP_IN-1].ep, DataSendBuf, ConfigDescriptor.endpoint[EP_IN-1].mps, 0);
+  
+  if(USB_ERROR_NONE != status)
+  {
+    platform_printf("[USB] data send error %d !\n", status);
+    ret = 1;
+  }
+  return ret;
+}
+
 void bsp_usb_disable(void)
 {
 
@@ -310,4 +327,3 @@ void bsp_usb_device_disconn_timeout(void)
   platform_printf("USB cable disconnected.");
 }
 #endif
-

--- a/src/BSP/bsp_usb.h
+++ b/src/BSP/bsp_usb.h
@@ -149,6 +149,7 @@ typedef struct
 extern void bsp_usb_init(void);
 extern void bsp_usb_disable(void);
 extern void bsp_usb_device_remote_wakeup(void);
+extern uint32_t bsp_usb_send_data(const uint8_t data[], uint32_t len);
 
 #ifdef FEATURE_DISCONN_DETECT
 void bsp_usb_device_disconn_timeout(void);


### PR DESCRIPTION
1、bsp_usb.c 中 USB_EVENT_EP_DATA_TRANSFER->USB_CALLBACK_TYPE_RECEIVE_END，接收数据时调用API不对，导致接收一次数据后无法再继续接收数据；
2、bsp_usb.c 中添加发送数据相关API。