### PR TITLE
Fix demo bug.

### DIFF
--- a/examples/io_over_ble_mas/src/io_interf.c
+++ b/examples/io_over_ble_mas/src/io_interf.c
@@ -136,8 +136,7 @@ static void config_uart(uint32_t freq, uint32_t baud)
 
 void io_interf_setup_peripherals()
 {
-    SYSCTRL_ClearClkGateMulti(   (1 << SYSCTRL_ClkGate_APB_PinCtrl)
-                              || (1 << SYSCTRL_ClkGate_APB_UART1));
+    SYSCTRL_ClearClkGateMulti((1 << SYSCTRL_ClkGate_APB_PinCtrl) | (1 << SYSCTRL_ClkGate_APB_UART1));
     config_uart(OSC_CLK_FREQ, 921600);
 
     PINCTRL_SetPadMux(PIN_COMM_RX, IO_SOURCE_GENERAL);


### PR DESCRIPTION
I/O Over BLE 例程中，串口时钟开启错误，导致连接成功后，使能 notify，串口引起 Hardfault。