### PR TITLE
USB TX FIFO flush error

### DIFF
--- a/src/FWlib/peripheral_usb.c
+++ b/src/FWlib/peripheral_usb.c
@@ -694,7 +694,7 @@ void USB_SetStallEp(uint8_t ep, uint8_t stall)
         {
           *diepctrl |= (0x1 << 21);
         }
-        USB_FlushTXFifo(0x10);
+        USB_FlushTXFifo(epNum);
       }
       else
       {


### PR DESCRIPTION
Fixed a USB issue where the TX FIFO of a non-0 endpoint was accidentally cleared by STALL operation of the 0 endpoint. 