### PR TITLE
Usb support sending zero length packet

### DIFF
--- a/src/BSP/bsp_usb.c
+++ b/src/BSP/bsp_usb.c
@@ -94,7 +94,7 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
                 case USB_REQUEST_DEVICE_DESCRIPTOR_DEVICE:
                 {
                   size = sizeof(USB_DEVICE_DESCRIPTOR_REAL_T);
-                  size = (setup->wLength < size) ? (setup->wLength) : size;
+                  size = (setup->wLength <= size) ? (setup->wLength) : ((size > USB_EP0_MPS) ? USB_EP0_MPS : size);
 
                   status |= USB_SendData(0, (void*)&DeviceDescriptor, size, 0);
                 }

--- a/src/BSP/bsp_usb_hid.c
+++ b/src/BSP/bsp_usb_hid.c
@@ -20,6 +20,18 @@ uint8_t DataSendBuf[EP_X_MPS_BYTES] __attribute__ ((aligned (4)));
 
 BSP_KEYB_DATA_s KeybReport __attribute__ ((aligned (4))) = {.pending = U_TRUE};
 BSP_MOUSE_DATA_s MouseReport __attribute__ ((aligned (4))) = {.pending = U_TRUE};
+
+uint32_t InterfaceProtocol[bNUM_INTERFACES] __attribute__ ((aligned (4)));
+
+static void usb_reset_handle(void)
+{
+  uint32_t i;
+  for(i=0; i<bNUM_INTERFACES; i++)
+  {
+    InterfaceProtocol[i] = USB_HID_PROTO_TYPE_REPORT;
+  }
+}
+
 static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
 {
   uint32_t size;
@@ -32,6 +44,7 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
       #ifdef FEATURE_DISCONN_DETECT
       platform_set_timer(bsp_usb_device_disconn_timeout,160);
       #endif
+      usb_reset_handle();
     }break;
     case USB_EVENT_DEVICE_SOF:
     {
@@ -253,6 +266,49 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
                 {
                   status = USB_ERROR_REQUEST_NOT_SUPPORT;
                 }break;
+              }
+            }
+            break;
+            case USB_REQUEST_HID_CLASS_REQUEST_GET_PROTOCOL:
+            {
+              uint8_t interface_num = (uint8_t)setup->wIndex;
+              if(setup->wLength == 1)
+              {
+                if(interface_num < bNUM_INTERFACES)
+                {
+                  status |= USB_SendData(0, (void*)&InterfaceProtocol[interface_num], 1, 0);
+                  status = USB_ERROR_NONE;
+                }
+                else
+                {
+                  status = USB_ERROR_REQUEST_NOT_SUPPORT;
+                }
+              }
+              else
+              {
+                status = USB_ERROR_REQUEST_NOT_SUPPORT;
+              }
+            }
+            break;
+            case USB_REQUEST_HID_CLASS_REQUEST_SET_PROTOCOL:
+            {
+              uint8_t protocol_type = (uint8_t)setup->wValue;
+              uint8_t interface_num = (uint8_t)setup->wIndex;
+              if(protocol_type == USB_HID_PROTO_TYPE_BOOT || protocol_type == USB_HID_PROTO_TYPE_REPORT)
+              {
+                if(interface_num < bNUM_INTERFACES)
+                {
+                  InterfaceProtocol[interface_num] = protocol_type;
+                  status = USB_ERROR_NONE;
+                }
+                else
+                {
+                  status = USB_ERROR_REQUEST_NOT_SUPPORT;
+                }
+              }
+              else
+              {
+                status = USB_ERROR_REQUEST_NOT_SUPPORT;
               }
             }
             break;

--- a/src/BSP/bsp_usb_hid.c
+++ b/src/BSP/bsp_usb_hid.c
@@ -91,7 +91,7 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
                 case USB_REQUEST_DEVICE_DESCRIPTOR_DEVICE:
                 {
                   size = sizeof(USB_DEVICE_DESCRIPTOR_REAL_T);
-                  size = (setup->wLength < size) ? (setup->wLength) : size;
+                  size = (setup->wLength <= size) ? (setup->wLength) : ((size > USB_EP0_MPS) ? USB_EP0_MPS : size);
 
                   status |= USB_SendData(0, (void*)&DeviceDescriptor, size, 0);
                 }

--- a/src/BSP/bsp_usb_hid.h
+++ b/src/BSP/bsp_usb_hid.h
@@ -426,6 +426,11 @@ typedef struct
   uint32_t unused:31;
 }BSP_USB_VAR_s;
 
+typedef enum {
+  USB_HID_PROTO_TYPE_BOOT   = 0x00,
+  USB_HID_PROTO_TYPE_REPORT = 0x01,
+} USB_HID_PROTO_TYPE_e;
+
 extern void bsp_usb_init(void);
 extern void bsp_usb_disable(void);
 extern void bsp_usb_device_remote_wakeup(void);

--- a/src/BSP/bsp_usb_msc.c
+++ b/src/BSP/bsp_usb_msc.c
@@ -1118,7 +1118,7 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
                   case USB_REQUEST_DEVICE_DESCRIPTOR_DEVICE:
                   {
                     size = sizeof(USB_DEVICE_DESCRIPTOR_REAL_T);
-                    size = (setup->wLength < size) ? (setup->wLength) : size;
+                    size = (setup->wLength <= size) ? (setup->wLength) : ((size > USB_EP0_MPS) ? USB_EP0_MPS : size);
 
                     status |= USB_SendData(0, (void*)&DeviceDescriptor, size, 0);
                   }

--- a/src/FWlib/peripheral_usb.h
+++ b/src/FWlib/peripheral_usb.h
@@ -420,12 +420,11 @@ extern USB_ERROR_TYPE_E USB_SendData(uint8_t ep, void* buffer, uint16_t size, ui
  * @param[in] size. For OUT transfers, the Transfer Size field in the endpoint Transfer Size register must be a multiple
  *            of the maximum packet size of the endpoint(eg, EP0 is 64byte), adjusted to the DWORD boundary
  * @param[in] flag. null
- * @param[out] return U_TRUE if successful, otherwise U_FALSE.
-              for example, if the MPS of ep is 64bytes, there are two options:
-              1. you know that you need to recieve exactly 64bytes, then set size to 64 and set flag to 0.
-                 the driver will only call the event handler when it has received all 64bytes.
-              2. you do know that size of next OUT packet, then set size to 64 and set to flag to 1<<USB_TRANSFERT_FLAG_FLEXIBLE_RECV_LEN.
-                 in this case, driver will call back the event handler when it receives its first packet(no matter what the size is).
+ *            for example, if the MPS of ep is 64bytes, there are two options:
+ *            1. you know that you need to recieve exactly 64bytes, then set size to 64 and set flag to 0.
+ *               the driver will only call the event handler when it has received all 64bytes.
+ *            2. you do know that size of next OUT packet, then set size to 64 and set to flag to 1<<USB_TRANSFERT_FLAG_FLEXIBLE_RECV_LEN.
+ *               in this case, driver will call back the event handler when it receives its first packet(no matter what the size is).
  * @param[out] return U_TRUE if successful, otherwise U_FALSE.
  */
 extern USB_ERROR_TYPE_E USB_RecvData(uint8_t ep, void* buffer, uint16_t size, uint32_t flag);


### PR DESCRIPTION
USB update:
1. Adjust the control endpoint logic timing to make it more intuitive, and discontinue the coupling judgment of USB_ContinueTransfer to prepare for the subsequent addition of new features.
2. Add the ability to send zero-length packets for USB_SendData. 
3. Fix enum error when USB_EP0_MPS = 8 or 16, Improve device compatibility with PCs.
4. Fix enumeration failure in some computer BIOS due to missing SET PROTOCOL and GET PROTOCOL.