### PR TITLE
Add uart check enable status API

### DIFF
--- a/src/FWlib/peripheral_uart.c
+++ b/src/FWlib/peripheral_uart.c
@@ -115,6 +115,21 @@ uint8_t apUART_Check_TXFIFO_FULL(UART_TypeDef* pBase)
 	return ( (pBase->Flag >> bsUART_TRANSMIT_FULL) & BW2M(bwUART_TRANSMIT_FULL) );
 }
 
+uint8_t apUART_Check_EnableSta(UART_TypeDef* pBase)
+{
+    return ( (pBase->Control >> bsUART_ENABLE) & BW2M(bwUART_ENABLE) );
+}
+
+uint8_t apUART_Check_TxEnableSta(UART_TypeDef* pBase)
+{
+    return ( (pBase->Control >> bsUART_TRANSMIT_ENABLE) & BW2M(bwUART_TRANSMIT_ENABLE) );
+}
+
+uint8_t apUART_Check_RxEnableSta(UART_TypeDef* pBase)
+{
+    return ( (pBase->Control >> bsUART_RECEIVE_ENABLE) & BW2M(bwUART_RECEIVE_ENABLE) );
+}
+
 uint8_t apUART_Check_BUSY(UART_TypeDef* pBase)
 {
 	return ( (pBase->Flag >> bsUART_BUSY) & BW2M(bwUART_BUSY) );

--- a/src/FWlib/peripheral_uart.h
+++ b/src/FWlib/peripheral_uart.h
@@ -319,6 +319,10 @@ uint8_t apUART_Check_RXFIFO_FULL(UART_TypeDef* pBase);
 uint8_t apUART_Check_TXFIFO_EMPTY(UART_TypeDef* pBase);
 uint8_t apUART_Check_TXFIFO_FULL(UART_TypeDef* pBase);
 
+uint8_t apUART_Check_EnableSta(UART_TypeDef* pBase);
+uint8_t apUART_Check_TxEnableSta(UART_TypeDef* pBase);
+uint8_t apUART_Check_RxEnableSta(UART_TypeDef* pBase);
+
 void apUART_Enable_TRANSMIT_INT(UART_TypeDef* pBase);
 void apUART_Disable_TRANSMIT_INT(UART_TypeDef* pBase);
 void apUART_Enable_RECEIVE_INT(UART_TypeDef* pBase);


### PR DESCRIPTION
Avoid the crash problem by adding an API to determine the status of the UART to restrict the call of certain functions, for example: while (apUART_Check_TXFIFO_FULL(PRINT_PORT) == 1);