### PR TITLE
[Fixed] 918X PWM example: use of magic numbers

### DIFF
--- a/src/BSP/board.c
+++ b/src/BSP/board.c
@@ -540,10 +540,9 @@ void set_buzzer_freq(uint16_t freq)
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
     PWM_SetupSimple(BUZZ_PWM_CH, freq, 50);
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
-    PWM_SetupSimple(0, freq, 50);
+    PWM_SetupSimple(BUZZ_PWM_CH, freq, 50);
 #endif
 }
-
 
 #else
 

--- a/src/BSP/board.c
+++ b/src/BSP/board.c
@@ -512,6 +512,8 @@ void get_acc_xyz(float *x, float *y, float *z)
 //-------------------------------------------------buzzer driver sort-------------------------------------------------
 #ifdef BOARD_USE_BUZZER
 
+#define BUZZ_PWM_CH     4
+
 #if ((BOARD_ID == BOARD_ING91881B_02_02_04) || (BOARD_ID == BOARD_ING91881B_02_02_05) || (BOARD_ID == BOARD_ING91881B_02_02_06))
 #define BUZZ_PIN        GIO_GPIO_8
 #elif (BOARD_ID ==  BOARD_DB682AC1A)
@@ -522,7 +524,7 @@ void setup_buzzer()
 {
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
     SYSCTRL_ClearClkGateMulti((1 << SYSCTRL_ClkGate_APB_PWM));
-    PINCTRL_SetGeneralPadMode(BUZZ_PIN, IO_MODE_PWM, 4, 0);
+    PINCTRL_SetGeneralPadMode(BUZZ_PIN, IO_MODE_PWM, BUZZ_PWM_CH, 0);
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
     SYSCTRL_ClearClkGateMulti( (1 << SYSCTRL_ClkGate_APB_PinCtrl)
                                     | (1 << SYSCTRL_ClkGate_APB_PWM));
@@ -536,11 +538,12 @@ void setup_buzzer()
 void set_buzzer_freq(uint16_t freq)
 {
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
-    PWM_SetupSimple(BUZZ_PIN >> 1, freq, 50);
+    PWM_SetupSimple(BUZZ_PWM_CH, freq, 50);
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
     PWM_SetupSimple(0, freq, 50);
 #endif
 }
+
 
 #else
 

--- a/src/BSP/board.c
+++ b/src/BSP/board.c
@@ -536,15 +536,9 @@ void setup_buzzer()
 
 void set_buzzer_freq(uint16_t freq)
 {
-#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
     PWM_SetupSimple(BUZZ_PWM_CH, freq, 50);
-#elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
-    PWM_SetupSimple(BUZZ_PWM_CH, freq, 50);
-#endif
 }
-
 #else
-
 void setup_buzzer()
 {
 }

--- a/src/BSP/board.c
+++ b/src/BSP/board.c
@@ -512,7 +512,7 @@ void get_acc_xyz(float *x, float *y, float *z)
 //-------------------------------------------------buzzer driver sort-------------------------------------------------
 #ifdef BOARD_USE_BUZZER
 
-#define BUZZ_PWM_CH     4
+#define BUZZ_PWM_CH     0
 
 #if ((BOARD_ID == BOARD_ING91881B_02_02_04) || (BOARD_ID == BOARD_ING91881B_02_02_05) || (BOARD_ID == BOARD_ING91881B_02_02_06))
 #define BUZZ_PIN        GIO_GPIO_8
@@ -522,12 +522,11 @@ void get_acc_xyz(float *x, float *y, float *z)
 
 void setup_buzzer()
 {
+    SYSCTRL_ClearClkGateMulti( (1 << SYSCTRL_ClkGate_APB_PinCtrl)
+    | (1 << SYSCTRL_ClkGate_APB_PWM));
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
-    SYSCTRL_ClearClkGateMulti((1 << SYSCTRL_ClkGate_APB_PWM));
     PINCTRL_SetGeneralPadMode(BUZZ_PIN, IO_MODE_PWM, BUZZ_PWM_CH, 0);
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
-    SYSCTRL_ClearClkGateMulti( (1 << SYSCTRL_ClkGate_APB_PinCtrl)
-                                    | (1 << SYSCTRL_ClkGate_APB_PWM));
     SYSCTRL_SelectPWMClk(SYSCTRL_CLK_32k);
     PINCTRL_SetPadMux(BUZZ_PIN, IO_SOURCE_PWM0_B);
 #else


### PR DESCRIPTION
void PWM_SetupSimple(const uint8_t channel_index, const uint32_t frequency, const uint16_t on_duty);第一个参数入参应该为PWM通道号。