### PR TITLE
kv update

### DIFF
--- a/examples/hid_keyboard/src/kv_impl.c
+++ b/examples/hid_keyboard/src/kv_impl.c
@@ -250,7 +250,10 @@ static int kv_do_append_key(kvkey_t key, const void *data, int len)
 {
     int aligned = (2 + len + 3) & ~0x3ul;
     const uint8_t *d = (const uint8_t *)data;
-    uint8_t t[4] = {len, key, d[0], d[1]};
+    uint8_t t[4] = {len, key, 0, 0};
+    
+    if(d != NULL && len > 0)
+        memcpy(t + 2, d, (len > 2 ? 2 : len));
 
     if (kv_storage_tail + aligned > DB_FLASH_ADDR_END)
         kv_do_gc(key);


### PR DESCRIPTION
Enhance code robustness: When the optimization level is higher than O2, solve the hardfault problem caused by 0 address read operations (for example, when the pointer d = NULL, use the d[0] operation). In this case, the compiler will add pseudo-instructions such as DCW or UDF to trigger a hardfault. Which pseudo-instruction to add depends on the compiler version. 