### PR TITLE
feat: Update peripheral drivers and interfaces

### DIFF
--- a/src/FWlib/peripheral_asdm.c
+++ b/src/FWlib/peripheral_asdm.c
@@ -67,8 +67,17 @@ int ASDM_SetSampleRate(ASDM_TypeDef *base, ASDM_SampleRate sample, ASDM_AgcMode 
 {
     float div;
     uint32_t rounded, i;
-    uint16_t hpf_arr[18] = {78, 16, 85, 17, 117, 23, 154, 31, 167, 34, 227, 47, 298, 63,
-        322, 68, 431, 94};
+    uint16_t hpf_arr[18] = {
+        4017, 4079,
+        4010, 4078,
+        3978, 4072,
+        3941, 4064,
+        3928, 4061,
+        3868, 4048,
+        3797, 4032,
+        3773, 4027,
+        3664, 4001,
+    };
 
     uint32_t pll_clk = SYSCTRL_GetPLLClk();
     if (pll_clk > 390000000)

--- a/src/FWlib/peripheral_asdm.h
+++ b/src/FWlib/peripheral_asdm.h
@@ -319,7 +319,7 @@ void ASDM_SetVol(ASDM_TypeDef *base, uint32_t vol);
  * @brief ADSM get out data
  *
  * @param [in] base              ASDM base address
- * @return [out]                  Dmicc 16bit data (data_next[15:0],data[15:0])
+ * @return [out]                  Dmic 16bit data (data_next[15:0],data[15:0])
  */
 uint32_t ASDM_GetOutData(ASDM_TypeDef *base);
 

--- a/src/FWlib/peripheral_dma.c
+++ b/src/FWlib/peripheral_dma.c
@@ -426,6 +426,17 @@ int DMA_MemCopy(int channel_id, void *dst, void *src, int size)
     return (state & (DMA_IRQ_ERROR | DMA_IRQ_ABORT)) ? 1 : 0;
 }
 
+void DMA_ConfigSrcBurstSize(DMA_Descriptor *pDesc, DMA_SrcBurstSize burst_size)
+{
+    pDesc->Ctrl &= ~(uint32_t)(0xF << bsDMA_SRC_BURSIZE);
+    pDesc->Ctrl |= (uint32_t)(burst_size << bsDMA_SRC_BURSIZE);
+}
+
+DMA_Descriptor *DMA_GetChannelDescriptor(int channel_id)
+{
+    return &(APB_DMA->Channels[channel_id].Descriptor);
+}
+
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
 #define bsDMA_DST_REQ_SEL        4
@@ -608,6 +619,7 @@ static DMA_TransferWidth DMA_GetPeripheralWidth(SYSCTRL_DMA src)
         case SYSCTRL_DMA_I2C0:
         case SYSCTRL_DMA_UART0_TX:
         case SYSCTRL_DMA_UART1_TX:
+            return DMA_WIDTH_BYTE;
 
         case SYSCTRL_DMA_SPI0_TX:
         case SYSCTRL_DMA_SPI0_RX:
@@ -624,7 +636,6 @@ static DMA_TransferWidth DMA_GetPeripheralWidth(SYSCTRL_DMA src)
         case SYSCTRL_DMA_QDEC0:
         case SYSCTRL_DMA_QDEC1:
         case SYSCTRL_DMA_QDEC2:
-            return DMA_WIDTH_32_BITS;
         case SYSCTRL_DMA_SDADC_RX:
             return DMA_WIDTH_32_BITS;
         default:

--- a/src/FWlib/peripheral_dma.h
+++ b/src/FWlib/peripheral_dma.h
@@ -392,6 +392,23 @@ uint32_t DMA_GetChannelIntState(int channel_id);
  * @param[in] state                     interrupt state (combination of `DMA_IRQ`) to be cleared.
  */
 void DMA_ClearChannelIntState(int channel_id, uint32_t state);
+
+/**
+ * @brief Modify source burst size in the DMA descriptor
+ *
+ * @param[in] pDesc             the descriptor
+ * @param[in] burst_size        Source burst size of `DMA_SrcBurstSize`, The burst transfer byte number is SrcBurstSize * SrcWidth.
+ */
+void DMA_ConfigSrcBurstSize(DMA_Descriptor *pDesc, DMA_SrcBurstSize burst_size);
+
+/*
+* @brief Get DMA descriptor of a channel
+*
+* @param[in] channel_id                channel id
+* @return                              DMA descriptor
+*/
+DMA_Descriptor *DMA_GetChannelDescriptor(int channel_id);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/FWlib/peripheral_gpio.c
+++ b/src/FWlib/peripheral_gpio.c
@@ -296,10 +296,10 @@ int GIO_EnableDeepSleepWakeupSource(GIO_Index_t io_index, uint8_t enable,
     else
         return -1;
 
-    if ((1 <= io_index) && (io_index <= 4)
-     || (7 <= io_index) && (io_index <= 17)
-     || (24 <= io_index) && (io_index <= 25)
-     || (29 <= io_index) && (io_index <= 35))
+    if (((1 <= io_index) && (io_index <= 4))
+     || ((7 <= io_index) && (io_index <= 17))
+     || ((24 <= io_index) && (io_index <= 25))
+     || ((29 <= io_index) && (io_index <= 35)))
     {
         if (io_index <= 31)
             GIO_MaskedWrite((volatile uint32_t *)(AON2_CTRL_BASE + 0x60), io_index, enable);
@@ -382,7 +382,6 @@ static uint8_t map_int_mode(const uint8_t enable, const GIO_IntTriggerType_t typ
         default:
             return 0;
         }
-        break;
 
     case GIO_INT_LOGIC:
         switch (enable)
@@ -394,12 +393,9 @@ static uint8_t map_int_mode(const uint8_t enable, const GIO_IntTriggerType_t typ
         default:
             return 0;
         }
-        break;
     default:
         return 0;
     }
-
-    return 0;
 }
 
 
@@ -497,7 +493,6 @@ uint8_t GIO_ReadOutputValue(const GIO_Index_t io_index)
     return (pDef->DataOut >> index) & 1;
 }
 
-
 void GIO_SetBits(const uint64_t index_mask)
 {
     APB_GPIO0->DoutSet |= index_mask & 0x1fffff;
@@ -587,10 +582,10 @@ int GIO_EnableDeepSleepWakeupSource(GIO_Index_t io_index, uint8_t enable,
     else
         return -1;
 
-    if ((1 <= io_index) && (io_index <= 4)
-        || (7 <= io_index) && (io_index <= 20)
-        || (24 <= io_index) && (io_index <= 31)
-        || (34 <= io_index) && (io_index <= 35))
+    if (((1 <= io_index) && (io_index <= 4))
+        || ((7 <= io_index) && (io_index <= 20))
+        || ((24 <= io_index) && (io_index <= 31))
+        || ((34 <= io_index) && (io_index <= 35)))
     {
         if (io_index <= 31)
             GIO_MaskedWrite((volatile uint32_t *)(AON2_CTRL_BASE + 0x30), io_index, enable);
@@ -610,6 +605,12 @@ int GIO_EnableDeepSleepWakeupSource(GIO_Index_t io_index, uint8_t enable,
         }
     }
     return 0;
+}
+
+void GIO_EnableDeeperSleepWakeupSourceGroupA(uint8_t enable, uint8_t level)
+{
+    GIO_MaskedWrite((volatile uint32_t *)(AON1_CTRL_BASE + 0x10), 9, (level & 1) ^ 1);
+    GIO_MaskedWrite((volatile uint32_t *)(AON1_CTRL_BASE + 0x10), 10, enable);
 }
 
 #endif

--- a/src/FWlib/peripheral_keyscan.c
+++ b/src/FWlib/peripheral_keyscan.c
@@ -51,34 +51,31 @@ uint8_t KEYSCAN_GetScannerEn(void)
     return ret;
 }
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
-uint8_t  KEYSCAN_SetTableModeEn(uint8_t enable)
+void  KEYSCAN_SetTableModeEn(uint8_t enable)
 {
     uint8_t offset = 1;
     uint8_t bits_width = 1;
     uint32_t data = (enable == 0) ? 0: 1;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_scanner_ctrl0, offset, bits_width, data);
-    return 0;
 }
 
-uint8_t  KEYSCAN_SetLpkeyModeEn(uint8_t enable)
+void  KEYSCAN_SetLpkeyModeEn(uint8_t enable)
 {
     uint8_t offset = 2;
     uint8_t bits_width = 1;
     uint32_t data = (enable == 0) ? 0: 1;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_scanner_ctrl0, offset, bits_width, data);
-    return 0;
 }
 
-uint8_t  KEYSCAN_SetPeReg(uint8_t enable)
+void  KEYSCAN_SetPeReg(uint8_t enable)
 {
     uint8_t offset = 3;
     uint8_t bits_width = 1;
     uint32_t data = (enable == 0) ? 0: 1;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_scanner_ctrl0, offset, bits_width, data);
-    return 0;
 }
 
 uint8_t  KEYSCAN_SetPsReg(uint8_t pull)
@@ -148,7 +145,6 @@ void KEYSCAN_DbClkSel(uint8_t sel)
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_debouncd_cfg1, offset, bits_width, data);
 #endif
-    return;
 }
 
 void KEYSCAN_SetReleaseTime(uint32_t time)
@@ -157,7 +153,6 @@ void KEYSCAN_SetReleaseTime(uint32_t time)
     uint8_t bits_width = 11;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_scanner_ctrl1, offset, bits_width, time);
-    return;
 }
 
 void KEYSCAN_SetScanInterval(uint32_t scan_itv)
@@ -166,7 +161,6 @@ void KEYSCAN_SetScanInterval(uint32_t scan_itv)
     uint8_t bits_width = 16;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_scanner_ctrl1, offset, bits_width, scan_itv);
-    return;
 }
 
 void KEYSCAN_SetOutRowMask(uint32_t row_mask)
@@ -179,7 +173,6 @@ void KEYSCAN_SetOutRowMask(uint32_t row_mask)
 #endif
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_row_mask_ctrl, offset, bits_width, row_mask);
-    return;
 }
 
 void KEYSCAN_SetInColMask(uint32_t col_mask)
@@ -192,7 +185,6 @@ void KEYSCAN_SetInColMask(uint32_t col_mask)
 #endif
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_col_mask_ctrl, offset, bits_width, col_mask);
-    return;
 }
 
 void KEYSCAN_SetIntTrigEn(uint8_t enable)
@@ -202,7 +194,6 @@ void KEYSCAN_SetIntTrigEn(uint8_t enable)
     uint32_t data = (enable == 0) ? 0: 1;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_int_en, offset, bits_width, data);
-    return;
 }
 
 void KEYSCAN_SetFifoClrReg(void)
@@ -212,7 +203,6 @@ void KEYSCAN_SetFifoClrReg(void)
     uint32_t data = 1;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_int_en, offset, bits_width, data);
-    return;
 }
 
 void KEYSCAN_LoopIntClr(void)
@@ -222,7 +212,6 @@ void KEYSCAN_LoopIntClr(void)
     uint32_t data = 1;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_int_en, offset, bits_width, data);
-    return;
 }
 
 void KEYSCAN_LoopIntEn(uint8_t enable)
@@ -232,7 +221,6 @@ void KEYSCAN_LoopIntEn(uint8_t enable)
     uint32_t data = (enable == 0) ? 0: 1;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_int_en, offset, bits_width, data);
-    return;
 }
 
 uint8_t KEYSCAN_GetIntStateFifoFullRaw(void)
@@ -291,7 +279,6 @@ void KEYSCAN_SetFifoNumTrigInt(uint32_t trig_num)
     uint8_t bits_width = 5;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_trig, offset, bits_width, trig_num);
-    return;
 }
 
 void KEYSCAN_SetDmaNumTrigInt(uint32_t trig_num)
@@ -300,7 +287,6 @@ void KEYSCAN_SetDmaNumTrigInt(uint32_t trig_num)
     uint8_t bits_width = 5;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_trig, offset, bits_width, trig_num);
-    return;
 }
 
 void KEYSCAN_SetLoopNumTrigInt(uint32_t trig_num)
@@ -309,7 +295,6 @@ void KEYSCAN_SetLoopNumTrigInt(uint32_t trig_num)
     uint8_t bits_width = 3;
 
     KEYSCAN_reg_write_bits(&APB_KEYSCAN->key_trig, offset, bits_width, trig_num);
-    return;
 }
 
 static uint8_t KEYSCAN_CheckStatePara(const KEYSCAN_SetStateStruct* keyscan_set)
@@ -357,93 +342,80 @@ uint8_t KEYSCAN_KeyDataToRowColIdx(const KEYSCAN_Ctx *ctx, uint32_t key_data, ui
     }
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
-uint8_t KEYSCAN_GetScanMode(uint8_t table_en, KEYSCAN_ScanMode_t* scan_mode, uint32_t key_data)
+uint8_t KEYSCAN_GetScanMode(KEYSCAN_ScanMode_t* scan_mode, uint32_t key_data)
 {
     uint8_t key_val = 0;
     key_val = (key_data>>8) & 0xf;
-    if(table_en){
-        switch (key_val) {
+    if(APB_KEYSCAN->key_scanner_ctrl0 & 0x2){
+            switch (key_val) {
+            case 0x7:
+                *scan_mode = SCAN_HIGH_PRESS;
+                break;
+            case 0x6:
+                *scan_mode = SCAN_LOW_PRESS;
+                break;
+            case 0x4:
+                *scan_mode = SCAN_NUMBER;
+                break;
             case 0x3:
-                *scan_mode = SCAN_HIGH;
+                *scan_mode = SCAN_HIGH_RELEASE;
+                break;
             case 0x2:
-                *scan_mode = SCAN_LOW;
+                *scan_mode = SCAN_LOW_RELEASE;
+                break;
             case 0x0:
                 *scan_mode = SCAN_NUMBER;
-            case 0x4:
-                return 0;
+                break;
             default:
+                *scan_mode = SCAN_NONE;
                 return 0;
         }
     } else {
         switch (key_val) {
-            case 0x7:
-                *scan_mode = SCAN_HIGH;
-                break;
-            case 0x6:
-                *scan_mode = SCAN_LOW;
-                break;
-            case 0x4:
-                *scan_mode = SCAN_NUMBER;
-                break;
             case 0x3:
-                *scan_mode = SCAN_HIGH;
+            *scan_mode = SCAN_HIGH_PRESS;
                 break;
             case 0x2:
-                *scan_mode = SCAN_LOW;
+            *scan_mode = SCAN_LOW_PRESS;
                 break;
             case 0x0:
-                *scan_mode = SCAN_NUMBER;
+            *scan_mode = SCAN_NUMBER;
                 break;
+            case 0x4:
             default:
-                return 0;
+            *scan_mode = SCAN_NONE;
+            return 0;
         }
     }
     return 1;
 }
 
-uint8_t KEYSCAN_NormalHighLowDataToIdex(const KEYSCAN_Ctx *ctx, uint32_t key_data, uint8_t *row, uint8_t *col)
+uint8_t KEYSCAN_HighLowDataToIdex(const KEYSCAN_Ctx *ctx, KEYSCAN_GET_Idx *Idx, uint32_t key_data)
 {
-    if((key_data & 0x1f) > (KEY_IN_COL_NUMBER - 1)){
-        *row = ctx->row_to_idx[((key_data & 0x1f) - KEY_IN_COL_NUMBER + 1)];
+    if ((ctx == 0) || (Idx == 0))
         return 1;
-    }
-    else{
-        *col = ctx->col_to_idx[(key_data & 0x1f)];
-    return 0;
-}
-}
 
-uint8_t KEYSCAN_TableHighLowDataToIdex(const KEYSCAN_Ctx *ctx, uint32_t key_data, uint8_t *row, uint8_t *col, uint8_t *key_stae)
-{
-    uint8_t key_val = 0;
-    key_val = (key_data>>8) & 0xf;
-    if((key_val == 0x7) || (key_val == 0x6)){
-        *key_stae = 1;
-    } else {
-        *key_stae = 0;
-    }
-
-    if((key_data & 0x1f) > (KEY_IN_COL_NUMBER - 1)){
-        *row = ctx->row_to_idx[((key_data & 0x1f) - KEY_IN_COL_NUMBER + 1)];
+    if (KEYSCAN_GetScanMode(&Idx->scan_mode, key_data) == 0)
         return 1;
-    }
-    else{
-        *col = ctx->col_to_idx[(key_data & 0x1f)];
+    if (Idx->scan_mode != SCAN_NUMBER) {
+        key_data &= 0x1ful;
+        if (key_data > (KEY_IN_COL_NUMBER - 1)) {
+            Idx->out_pin = ctx->row_to_idx[key_data - KEY_IN_COL_NUMBER];
+        }
+        else {
+            Idx->out_pin = ctx->col_to_idx[key_data];
+        }
+        Idx->in_pin = 0xff;
         return 0;
     }
-
-
-}
-
-void KEYSCAN_ScanDataToIdex(const KEYSCAN_Ctx *ctx, KEYSCAN_RunMode_t mode, uint32_t key_data, uint8_t *row, uint8_t *col)
-{
-    if(mode == NORMAL_MODE){
-        *row = ctx->row_to_idx[(key_data >> 5) & 0x07];
-    *col = ctx->col_to_idx[key_data & 0x1f];
-    } else if (mode == LPKEY_MODE) {
-        *row = ctx->row_to_idx[(key_data >> 4) & 0xf];
-        *col = ctx->col_to_idx[key_data & 0xf];
-}
+    if (APB_KEYSCAN->key_scanner_ctrl0 & 0x4) {
+        Idx->out_pin = ctx->col_to_idx[(key_data >> 4)&0xf];
+        Idx->in_pin = ctx->col_to_idx[key_data & 0xf];
+    } else {
+        Idx->out_pin = ctx->row_to_idx[(key_data >> 5)&0xf];
+        Idx->in_pin = ctx->col_to_idx[key_data & 0x1f];
+    }
+    return 0;
 }
 
 #endif

--- a/src/FWlib/peripheral_keyscan.h
+++ b/src/FWlib/peripheral_keyscan.h
@@ -73,11 +73,25 @@ typedef enum
 } KEYSCAN_OutRowIndex_t;
 
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+/*
+ * Keyscan Scan result enumeration.
+ *
+ * SCAN_HIGH_PRESS: A button with one pin connected to VCC is pressed.
+ * SCAN_LOW_PRESS: A button with one pin connected to GND is pressed.
+ * SCAN_HIGH_RELEASE: A button with one pin connected to VCC is released.
+ * SCAN_LOW_RELEASE: A button with one pin connected to GND is released.
+ * SCAN_NUMBER: The number of scan results.
+ * SCAN_NONE: Input data is error or end loop.
+ */
 typedef  enum {
-    SCAN_HIGH,
-    SCAN_LOW,
+    SCAN_HIGH_PRESS,
+    SCAN_LOW_PRESS,
+    SCAN_HIGH_RELEASE,
+    SCAN_LOW_RELEASE,
     SCAN_NUMBER,
+    SCAN_NONE,
 }KEYSCAN_ScanMode_t;
+
 typedef enum {
     NORMAL_MODE,
     LPKEY_MODE,
@@ -99,6 +113,22 @@ typedef struct
     uint8_t row_to_idx[KEY_OUT_ROW_NUMBER];
     uint8_t col_to_idx[KEY_IN_COL_NUMBER];
 } KEYSCAN_Ctx;
+
+/*
+ * Keyscan Data Result Structure.
+ *
+ * scan_mode : Scan mode. See KEYSCAN_ScanMode_t.
+ * out_pin : In normal mode, it is the row pin. In LPKEY mode, it is the output pin.
+ * in_pin : In normal mode, it is the column pin. In LPKEY mode, it is the input pin.
+ *
+ * NOTE: In LPKEY mode, Both output and input pins are row pins.
+ */
+typedef struct
+{
+    KEYSCAN_ScanMode_t scan_mode;
+    uint8_t out_pin;
+    uint8_t in_pin;
+} KEYSCAN_GET_Idx;
 
 typedef struct {
     KEYSCAN_InColList *col;
@@ -210,56 +240,20 @@ void KEYSCAN_InitKeyScanToIdx(const KEYSCAN_SetStateStruct* keyscan_set, KEYSCAN
  */
 uint8_t KEYSCAN_KeyDataToRowColIdx(const KEYSCAN_Ctx *ctx, uint32_t key_data, uint8_t *row, uint8_t *col);
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
-/**
- * @brief Gets the value of the key scan mode
- *
- * @param[in]  table_en          keyscan table mode enable?
- * @param[in]  scan_mode         key scan mode
- * @param[out] key_data          keyscan FIFO raw data
- * @return                       0: scan cycle end data or error;
- *                               1: find key pressed, *row and *col are key positions in keyboard array
- */
-uint8_t KEYSCAN_GetScanMode(uint8_t table_en, KEYSCAN_ScanMode_t* scan_mode, uint32_t key_data);
-/**
- * @brief In normal mode, transfer keyscan FIFO raw data to keyboard array row and col
- *
- * To use this helper function, `ctx` must be initialized with `KEYSCAN_InitKeyScanToIdx`.
- *
- * @param[in]  ctx              keyboard array mapping table
- * @param[in]  key_data         keyscan FIFO raw data
- * @param[out] row              pressed key's 0-based row index in keyboard array
- * @param[out] col              pressed key's 0-based col index in keyboard array
- * @return                      0: scan key vale is row
- *                              1: scan key vale is col
- */
-uint8_t KEYSCAN_NormalHighLowDataToIdex(const KEYSCAN_Ctx *ctx, uint32_t key_data, uint8_t *row, uint8_t *col);
-/**
- * @brief In table mode, transfer keyscan FIFO raw data to keyboard array row and col
- *
- * To use this helper function, `ctx` must be initialized with `KEYSCAN_InitKeyScanToIdx`.
- *
- * @param[in]  ctx              keyboard array mapping table
- * @param[in]  key_data         keyscan FIFO raw data
- * @param[out] row              pressed key's 0-based row index in keyboard array
- * @param[out] col              pressed key's 0-based col index in keyboard array
- * @param[out] key_stae         key state press or unpress
- * @return                      0: scan key vale is row
- *                              1: scan key vale is col
- */
-uint8_t KEYSCAN_TableHighLowDataToIdex(const KEYSCAN_Ctx *ctx, uint32_t key_data, uint8_t *row, uint8_t *col, uint8_t *key_stae);
+
 /**
  * @brief Transfer keyscan FIFO raw data to keyboard array row and col
  *
  * To use this helper function, `ctx` must be initialized with `KEYSCAN_InitKeyScanToIdx`.
  *
  * @param[in]  ctx              keyboard array mapping table
- * @param[in]  mode             keyscan mode lpkey or normal
+ * @param[out] Idx              Transfer struct, contains row and col index and keyscan mode.
  * @param[in]  key_data         keyscan FIFO raw data
- * @param[out] row              pressed key's 0-based row index in keyboard array
- * @param[out] col              pressed key's 0-based col index in keyboard array
- *
+ * @return                      0: Success;
+ *                              1: error arg or keyscan_data
  */
-void KEYSCAN_ScanDataToIdex(const KEYSCAN_Ctx *ctx, KEYSCAN_RunMode_t mode, uint32_t key_data, uint8_t *row, uint8_t *col);
+uint8_t KEYSCAN_HighLowDataToIdex(const KEYSCAN_Ctx *ctx, KEYSCAN_GET_Idx *Idx, uint32_t key_data);
+
 #endif
 /**
  * @brief Set keyscan start scan

--- a/src/FWlib/peripheral_pte.h
+++ b/src/FWlib/peripheral_pte.h
@@ -122,6 +122,163 @@ int PTE_ConnectPeripheral(SYSCTRL_PTE_CHANNEL_ID ch,
 
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
+/*
+ * PTE EVENT enum
+ */
+typedef enum
+{
+    PTE_TASK_QDEC_CH0_START = 0,
+    PTE_TASK_QDEC_CH0_STOP,
+    PTE_TASK_QDEC_CH1_START,
+    PTE_TASK_QDEC_CH1_STOP,
+    PTE_TASK_QDEC_CH2_START,
+    PTE_TASK_QDEC_CH2_STOP,
+
+    PTE_TASK_GPIOTE_TOGGLE_CH0 = 0,
+    PTE_TASK_GPIOTE_TOGGLE_CH1,
+    PTE_TASK_GPIOTE_TOGGLE_CH2,
+    PTE_TASK_GPIOTE_TOGGLE_CH3,
+    PTE_TASK_GPIOTE_TOGGLE_CH4,
+    PTE_TASK_GPIOTE_TOGGLE_CH5,
+    PTE_TASK_GPIOTE_TOGGLE_CH6,
+    PTE_TASK_GPIOTE_TOGGLE_CH7,
+    PTE_TASK_GPIOTE_HIGH_CH0,
+    PTE_TASK_GPIOTE_HIGH_CH1,
+    PTE_TASK_GPIOTE_HIGH_CH2,
+    PTE_TASK_GPIOTE_HIGH_CH3,
+    PTE_TASK_GPIOTE_HIGH_CH4,
+    PTE_TASK_GPIOTE_HIGH_CH5,
+    PTE_TASK_GPIOTE_HIGH_CH6,
+    PTE_TASK_GPIOTE_HIGH_CH7,
+    PTE_TASK_GPIOTE_LOW_CH0,
+    PTE_TASK_GPIOTE_LOW_CH1,
+    PTE_TASK_GPIOTE_LOW_CH2,
+    PTE_TASK_GPIOTE_LOW_CH3,
+    PTE_TASK_GPIOTE_LOW_CH4,
+    PTE_TASK_GPIOTE_LOW_CH5,
+    PTE_TASK_GPIOTE_LOW_CH6,
+    PTE_TASK_GPIOTE_LOW_CH7,
+
+    PTE_TASK_TIMER_CH0_TM0_START = 0,
+    PTE_TASK_TIMER_CH0_TM1_START,
+    PTE_TASK_TIMER_CH0_TM2_START,
+    PTE_TASK_TIMER_CH0_TM3_START,
+    PTE_TASK_TIMER_CH1_TM0_START,
+    PTE_TASK_TIMER_CH1_TM1_START,
+    PTE_TASK_TIMER_CH1_TM2_START,
+    PTE_TASK_TIMER_CH1_TM3_START,
+    PTE_TASK_TIMER_CH0_TM0_STOP,
+    PTE_TASK_TIMER_CH0_TM1_STOP,
+    PTE_TASK_TIMER_CH0_TM2_STOP,
+    PTE_TASK_TIMER_CH0_TM3_STOP,
+    PTE_TASK_TIMER_CH1_TM0_STOP,
+    PTE_TASK_TIMER_CH1_TM1_STOP,
+    PTE_TASK_TIMER_CH1_TM2_STOP,
+    PTE_TASK_TIMER_CH1_TM3_STOP,
+
+    PTE_TASK_SPI_MASTER_DMA_TX_START = 0,
+    PTE_TASK_SPI_MASTER_DMA_TX_STOP,
+
+    PTE_TASK_I2C_MASTER_DMA_TX = 0,
+
+    PTE_TASK_ADC_START = 0,
+    PTE_TASK_ADC_LOOP,
+    PTE_TASK_ADC_DMA_STOP_TX,
+
+    PTE_TASK_UART_DMA_TX_START = 0,
+    PTE_TASK_UART_DMA_TX_STOP,
+    PTE_TASK_UART_DMA_RX_START,
+    PTE_TASK_UART_DMA_RX_STOP,
+
+    PTE_TASK_PWM_CH0_IR_START = 0,
+    PTE_TASK_PWM_CH0_ONE_PULSE,
+    PTE_TASK_PWM_CH0_PWM_START,
+    PTE_TASK_PWM_CH0_PWM_DMA_START,
+    PTE_TASK_PWM_CH0_PCM_START,
+    PTE_TASK_PWM_CH0_PWM_STOP,
+    PTE_TASK_PWM_CH0_PCM_STOP,
+    PTE_TASK_PWM_CH1_IR_START,
+    PTE_TASK_PWM_CH1_ONE_PULSE,
+    PTE_TASK_PWM_CH1_PWM_START,
+    PTE_TASK_PWM_CH1_PWM_DMA_START,
+    PTE_TASK_PWM_CH1_PCM_START,
+    PTE_TASK_PWM_CH1_PWM_STOP,
+    PTE_TASK_PWM_CH1_PCM_STOP,
+    PTE_TASK_PWM_CH2_IR_START,
+    PTE_TASK_PWM_CH2_ONE_PULSE,
+    PTE_TASK_PWM_CH2_PWM_START,
+    PTE_TASK_PWM_CH2_PWM_DMA_START,
+    PTE_TASK_PWM_CH2_PCM_START,
+    PTE_TASK_PWM_CH2_PWM_STOP,
+    PTE_TASK_PWM_CH2_PCM_STOP,
+
+    PTE_TASK_I2S_DMA_TX_START = 0,
+    PTE_TASK_I2S_DMA_RX_START,
+    PTE_TASK_I2S_DMA_TX_STOP,
+    PTE_TASK_I2S_DMA_RX_STOP,
+
+    PTE_TASK_ASDM_RX_START = 0,
+    PTE_TASK_ASDM_RX_STOP,
+}PTE_Task;
+
+/*
+ * PTE EVENT enum
+ */
+typedef enum
+{
+    PTE_EVENT_QDEC_CH0_STOP_CPL = 0,
+    PTE_EVENT_QDEC_CH1_STOP_CPL,
+    PTE_EVENT_QDEC_CH2_STOP_CPL,
+
+    PTE_EVENT_DMA_CH0_STOP_CPL = 0,
+    PTE_EVENT_DMA_CH1_STOP_CPL,
+    PTE_EVENT_DMA_CH2_STOP_CPL,
+    PTE_EVENT_DMA_CH3_STOP_CPL,
+    PTE_EVENT_DMA_CH4_STOP_CPL,
+    PTE_EVENT_DMA_CH5_STOP_CPL,
+    PTE_EVENT_DMA_CH6_STOP_CPL,
+    PTE_EVENT_DMA_CH7_STOP_CPL,
+
+    PTE_EVENT_GPIOTE_CH0_INPUT_INT = 0,
+    PTE_EVENT_GPIOTE_CH1_INPUT_INT,
+    PTE_EVENT_GPIOTE_CH2_INPUT_INT,
+    PTE_EVENT_GPIOTE_CH3_INPUT_INT,
+    PTE_EVENT_GPIOTE_CH4_INPUT_INT,
+    PTE_EVENT_GPIOTE_CH5_INPUT_INT,
+    PTE_EVENT_GPIOTE_CH6_INPUT_INT,
+    PTE_EVENT_GPIOTE_CH7_INPUT_INT,
+
+    PTE_EVENT_TIMER_CH0_TIM0_TIM_UP = 0,
+    PTE_EVENT_TIMER_CH0_TIM1_TIM_UP,
+    PTE_EVENT_TIMER_CH0_TIM2_TIM_UP,
+    PTE_EVENT_TIMER_CH0_TIM3_TIM_UP,
+    PTE_EVENT_TIMER_CH1_TIM0_TIM_UP,
+    PTE_EVENT_TIMER_CH1_TIM1_TIM_UP,
+    PTE_EVENT_TIMER_CH1_TIM2_TIM_UP,
+    PTE_EVENT_TIMER_CH1_TIM3_TIM_UP,
+
+    PTE_EVENT_SPI_TX_END = 0,
+
+    PTE_EVENT_I2C_TX_CPL = 0,
+
+    PTE_EVENT_ADC_DATA_CPL = 0,
+    PTE_EVENT_ADC_DMA_STOP_TX,
+
+    PTE_EVENT_UART_TX_INT = 0,
+    PTE_EVENT_UART_RX_INT,
+
+    PTE_EVENT_PWM_CH0_PWM_STOP = 0,
+    PTE_EVENT_PWM_CH0_FIFO_TRG,
+    PTE_EVENT_PWM_CH0_PCM_STOP,
+    PTE_EVENT_PWM_CH1_PWM_STOP,
+    PTE_EVENT_PWM_CH1_FIFO_TRG,
+    PTE_EVENT_PWM_CH1_PCM_STOP,
+    PTE_EVENT_PWM_CH2_PWM_STOP,
+    PTE_EVENT_PWM_CH2_FIFO_TRG,
+    PTE_EVENT_PWM_CH2_PCM_STOP,
+
+    PTE_EVENT_ASDM_RX_DATA = 0,
+}PTE_Event;
 
 /**
  * @brief PTE can used modules
@@ -177,65 +334,35 @@ typedef enum
 }PTE_Channel;
 
 /**
- * @brief PTE Module Evevt and task
+ * @brief GPIOTE channel
+ *
+ * Range: 0 ~ 7
  */
 typedef enum
 {
-    PTE_EVENT_QDEC_TMR_STOP = 0,
-    PTE_TASK_QDEC_TMR_STOP,
-    PTE_TASK_QDEC_TMR_START,
+    GPIOTE_CHANNEL_0 = 0,
+    GPIOTE_CHANNEL_1,
+    GPIOTE_CHANNEL_2,
+    GPIOTE_CHANNEL_3,
+    GPIOTE_CHANNEL_4,
+    GPIOTE_CHANNEL_5,
+    GPIOTE_CHANNEL_6,
+    GPIOTE_CHANNEL_7,
+} GPIOTE_Channel;
 
-    PTE_EVENT_DMA_TRANS_CMPL = 0,
-
-    PTE_EVENT_GPIO_INT = 0,
-    PTR_TASK_GPIO_OUT,
-    PTE_TASK_GPIO_SET,
-    PTE_TASK_GPIO_CLR,
-
-    PTE_EVENT_TIMER_CHX_TMRX = 0,
-    PTE_TASK_TIMER_CHX_TMRX_ENABLE,
-    PTE_TASK_TIMER_CHX_TMRX_DISABLE,
-
-    PTE_EVENT_SPI_TRANS_END = 0,
-    PTE_TASK_SPI_INITIATE,
-    PTE_TASK_SPI_TERMINATE,
-
-    PTE_EVENT_IIC_TRANS_CMPL = 0,
-    PTE_TASK_IIC_ISSUE_TRANS,
-
-    PTE_EVENT_ADC_SMP_DONE = 0,
-    PTE_EVENT_ADC_SMP_STOP,
-    PTE_TASK_ADC_SINGLE_START,
-    PTE_TASK_ADC_LOOP_SMP_START,
-    PTE_TASK_ADC_LOOP_SMP_STOP,
-
-    PTE_EVENT_UART_TX_FIFO_TRIGE = 0,
-    PTE_EVENT_UART_RX_FIFO_TRIGE,
-    PTE_TASK_UART_TX_ENABLE,
-    PTE_TASK_UART_TX_DISABLE,
-    PTE_TASK_UART_RX_ENABLE,
-    PTE_TASK_UART_RX_DISABLE,
-
-    PTE_TASK_I2S_TX_FIFO_TRIGE_ENABLE = 0,
-    PTE_TASK_I2S_RX_FIFO_TRIGE_ENABLE,
-    PTE_TASK_I2S_TX_WR_RST_MEM_DISABLE,
-    PTE_TASK_I2S_RX_WR_RST_MEM_DISABLE,
-
-    PTE_EVENT_PWM_CX_PWM_STOP = 0,
-    PTE_EVENT_PWM_CX_FIFO_TRIG,
-    PTE_EVENT_PWM_CX_PCM_STOP,
-    PTE_TASK_PWM_CX_ONE_PWM,
-    PTE_TASK_PWM_CX_PWM_START,
-    PTE_TASK_PWM_CX_PWM_DMA_START,
-    PTE_TASK_PWM_CX_PWM_STOP,
-    PTE_TASK_PWM_CX_IR_START,
-    PTE_TASK_PWM_CX_PCM_START,
-    PTE_TASK_PWM_CX_PCM_STOP,
-
-    PTE_EVENT_ASDM_RX_STOP = 0,
-    PTE_TASK_ASDM_CONVERSION_START,
-    PTE_TASK_ASDM_CONVERSION_STOP,
-}PTE_ModuleTaskEvt;
+/**
+ * @brief GPIOTE channel mode
+ *
+ * Range: [0, 3]
+ *
+ * Default: GPIOTE_CHANNEL_DISABLE
+ */
+typedef enum
+{
+    GPIOTE_CHANNEL_DISABLE = 0,
+    GPIOTE_CHANNEL_EVENT = 1,
+    GPIOTE_CHANNEL_TASK = 3,
+} GPIOTE_Mode;
 
 /**
  * @brief PTEC channel group
@@ -260,6 +387,7 @@ typedef enum
  * @example Enable channel0 and channel1 PTE_ChxEnable((1<<PTE_CHANNEL_0) | (1<<PTE_CHANNEL_1))
  */
 void PTE_ChxEnable(uint32_t items);
+
 /**
  * @brief PTE channel disable
  *
@@ -268,6 +396,7 @@ void PTE_ChxEnable(uint32_t items);
  * @example Disable channel0 and channel1 PTE_ChxEnable((1<<PTE_CHANNEL_0) | (1<<PTE_CHANNEL_1))
  */
 void PTE_ChxDisable(uint32_t items);
+
 /**
  * @brief Get PTE channel enable state
  *
@@ -275,79 +404,60 @@ void PTE_ChxDisable(uint32_t items);
  * @return  combination of bits whose positions are listed in `PTE_Channel`
  */
 uint32_t PTE_ChxGetEnableState(void);
-/**
- * @brief Configure task or event parameters of the PTE peripheral module
- *
- * @param SetPTEModule      Set PTE peripheral module. Must be one of `PTE_Module`
- * @param SetTaskChannel    Set PTE task channel. Must be one of `PTE_Channel`
- * @param PTETaskEvt       Set PTE task event. Must be one of `PTE_ModuleTaskEvt`
- * @param TaskEvtSer       Set PTE task event serial number.(The module serial number can be viewed in the PTE_ModuleTaskEvt comment)
- * @return                 0 : failed, 1 : success
- * @example Set Qdec module task config,channel 0,task is QDEC_TMR_STOP,serial number is 1
- *          PTE_SetModuleTaskEventConfig(PTE_MODULE_QDEC, PTE_CHANNEL_0, PTE_TASK_QDEC_TMR_STOP, 1)
- */
-uint8_t PTE_SetModuleTaskEventConfig(PTE_Module SetPTEModule, PTE_Channel SetTaskChannel, PTE_ModuleTaskEvt PTETaskEvt, uint32_t TaskEvtSer);
-/**
- * @brief Ctrl task or event of the PTE peripheral module
- *
- * @param SetPTEModule      Set PTE peripheral module. Must be one of `PTE_Module`
- * @param PTETaskEvt       Set PTE task event. Must be one of `PTE_ModuleTaskEvt`
- * @param enable           Set PTE task event enable or disable.(1:enable,0:disable)
- * @param TaskEvtSer       Set PTE task event serial number.(The module serial number can be viewed in the PTE_ModuleTaskEvt comment)
- * @return                 0 : failed, 1 : success
- * @example Ctrl Qdec module task enable,task is QDEC_TMR_STOP,serial number is 1
- *          PTE_TaskEnable(PTE_MODULE_QDEC, PTE_TASK_QDEC_TMR_STOP, 1,0)
- */
-uint8_t PTE_TaskEnable(PTE_Module SetPTEModule, PTE_ModuleTaskEvt PTETaskEvt, uint8_t enable, uint32_t TaskEvtSer);
+
 /**
  * @brief Trigger task of the peripheral module PTE
  *
- * @param SetPTEModule      Set PTE peripheral module. Must be one of `PTE_Module`
- * @param PTETaskEvt       Set PTE task event. Must be one of `PTE_ModuleTaskEvt`
- * @param TaskEvtSer       Set PTE task event serial number.(The module serial number can be viewed in the PTE_ModuleTaskEvt comment)
- * @return                 0 : failed, 1 : success
- * @example Trigger Qdec module task,task is QDEC_TMR_STOP,serial number is 1
- *          PTE_TriggerTask(PTE_MODULE_QDEC, PTE_TASK_QDEC_TMR_STOP, 1)
+ * @param module      Set PTE peripheral module. Must be one of `PTE_Module`
+ * @param Task       Set PTE task event. Must be one of `PTE_Task`
+ * @return                 0 : success, 1 : input arg error
+ * @example Trigger Qdec module task,task is QDEC_TMR_STOP
+ *          PTE_TriggerTask(PTE_MODULE_QDEC, PTE_TASK_QDEC_CH0_START)
  */
-uint8_t PTE_TriggerTask(PTE_Module SetPTEModule, PTE_ModuleTaskEvt PTETaskEvt, uint32_t TaskEvtSer);
+uint8_t PTE_TriggerTask(PTE_Module module, PTE_Task Task);
+
 /**
- * @brief Enable PTE channel group
+ * @brief Enable PTE channel group, already send group task signal.
  *
- * @param PTEC_ChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
+ * @param SetChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
  * @return                 None
  * @example Enbale PTE channel group 0
  *          PTE_SetTaskChxGroupEN(PTEC_CHANNEL_GROUP_0)
  */
 void PTE_SetTaskChxGroupEN(PTEC_ChannelGroup SetChannelGroup);
+
 /**
- * @brief Disable PTE channel group
+ * @brief Disable PTE channel group, stop group task signal.
  *
- * @param PTEC_ChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
+ * @param SetChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
  * @return                 None
  * @example Disable PTE channel group 0
  *          PTE_SetTaskChxGroupDis(PTEC_CHANNEL_GROUP_0)
  */
 void PTE_SetTaskChxGroupDis(PTEC_ChannelGroup SetChannelGroup);
+
 /**
  * @brief Configure PTE channel group enable subscription
  *
- * @param PTEC_ChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
+ * @param SetChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
  * @param SetSubChannel          combination of bits whose positions are listed in `PTEC_ChannelGroup`
  * @return                 None
  * @example Cfg PTE channel group 0,subscription of TASKS_CHGX_EN Group1
- *          PTE_SetTaskChxGroupEnConfig(PTEC_CHANNEL_GROUP_0,(1<<PTEC_CHANNEL_GROUP_1))
+ *          PTE_SetTaskSubChxGroupEn(PTEC_CHANNEL_GROUP_0,(1<<PTEC_CHANNEL_GROUP_1))
  */
-void PTE_SetTaskChxGroupEnConfig(PTEC_ChannelGroup SetChannelGroup,uint32_t SetSubChannel);
+void PTE_SetTaskSubChxGroupEn(PTEC_ChannelGroup SetChannelGroup,PTE_Channel SetSubChannel);
+
 /**
  * @brief Configure PTE channel group disable subscription
  *
- * @param PTEC_ChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
+ * @param SetChannelGroup      PTE group. Must be one of `PTEC_ChannelGroup`
  * @param SetSubChannel          combination of bits whose positions are listed in `PTEC_ChannelGroup`
  * @return                 None
  * @example Cfg PTE channel group 0,subscription of TASKS_CHGX_DIS Group1
- *          PTE_SetTaskChxGroupDisConfig(PTEC_CHANNEL_GROUP_0,(1<<PTEC_CHANNEL_GROUP_1))
+ *          PTE_SetTaskSubChxGroupDis(PTEC_CHANNEL_GROUP_0,(1<<PTEC_CHANNEL_GROUP_1))
  */
-void PTE_SetTaskChxGroupDisConfig(PTEC_ChannelGroup SetChannelGroup,uint32_t SetSubChannel);
+void PTE_SetTaskSubChxGroupDis(PTEC_ChannelGroup SetChannelGroup,PTE_Channel SetSubChannel);
+
 /**
  * @brief Configure PTE channel group map
  *
@@ -361,6 +471,42 @@ void PTE_SetTaskChxGroupDisConfig(PTEC_ChannelGroup SetChannelGroup,uint32_t Set
  *          PTE_SetTaskChxGroupMap(PTEC_CHANNEL_GROUP_0,(1<<PTE_CHANNEL_0)|(1<<PTE_CHANNEL_1)|(1<<PTE_CHANNEL_2)|(1<<PTE_CHANNEL_3)
  */
 void PTE_SetTaskChxGroupMap(PTEC_ChannelGroup SetChannelGroup,uint32_t SetGroupMap);
+
+/**
+ * @brief Configure task parameters of the PTE peripheral module
+ *
+ * @param module      Set PTE peripheral module. Must be one of `PTE_Module`
+ * @param Task       Set PTE task configuration. Must be one of `PTE_Task`
+ * @param SetTaskChannel    Set PTE task channel. Must be one of `PTE_Channel`
+ * @param enable      Set PTE task enable or disable.
+ * @return                 other : failed, 0 : success
+ * @example Set Qdec module task config,channel 0,task is PTE_TASK_QDEC_CH0_START,
+ *          PTE_ConfigTask(PTE_MODULE_QDEC, PTE_TASK_QDEC_CH0_START, PTE_CHANNEL_0, 1)
+ */
+uint8_t PTE_ConfigTask(PTE_Module module, PTE_Task Task, PTE_Channel SetTaskChannel, uint8_t enable);
+
+/**
+ * @brief Configure task parameters of the PTE peripheral module
+ *
+ * @param module      Set PTE peripheral module. Must be one of `PTE_Module`
+ * @param Event       Set PTE task configuration. Must be one of `PTE_Task`
+ * @param SetEventChannel    Set PTE task channel. Must be one of `PTE_Channel`
+ * @param enable      Set PTE task enable or disable.
+ * @return                 other : failed, 0 : success
+ * @example Set Qdec module task config,channel 0,event is PTE_EVENT_QDEC_CH0_STOP_CPL,
+ *          PTE_ConfigEvent(PTE_MODULE_QDEC, PTE_EVENT_QDEC_CH0_STOP_CPL, PTE_CHANNEL_0, 1)
+ */
+uint8_t PTE_ConfigEvent(PTE_Module module, PTE_Event Event, PTE_Channel SetEventChannel, uint8_t enable);
+
+/**
+ * @brief Configure task or event parameters of the GPIOTE peripheral module.
+ *
+ * @param channel Set GPIOTE channel. Must be one of `GPIOTE_Channel`
+ * @param mode Set GPIOTE mode. Must be one of `GPIOTE_Mode`.
+ * @param pin IO pin number.
+ * @param out_level GPIOTE normal output level.  0: low level, 1: high level
+ */
+void GPIOTE_Configuration(GPIOTE_Channel channel, GPIOTE_Mode mode, uint8_t pin, uint8_t out_level);
 
 #ifdef __cplusplus
 } /* allow C++ to use these headers */

--- a/src/FWlib/peripheral_timer.c
+++ b/src/FWlib/peripheral_timer.c
@@ -323,7 +323,7 @@ void TMR_WatchDogClearInt(void)
 
 uint32_t RTMR_GetCNT(RTMR_TypeDef *pRTMR)
 {
-	return pRTMR->CNT;
+    return pRTMR->CNT;
 }
 
 void RTMR_Reload(RTMR_TypeDef *pRTMR)
@@ -331,56 +331,50 @@ void RTMR_Reload(RTMR_TypeDef *pRTMR)
     pRTMR->CTL |= 1 << bsRTMR_CTL_RELOAD;
 }
 
-//-----------
-// TMR_CMP
-//
 void RTMR_SetCMP(RTMR_TypeDef *pRTMR, uint32_t value)
 {
-	pRTMR->CMP = value;
+    pRTMR->CMP = value;
 }
 
 uint32_t RTMR_GetCMP(RTMR_TypeDef *pRTMR)
 {
-	return pRTMR->CMP;
+    return pRTMR->CMP;
 }
 
-//
 void RTMR_Enable(RTMR_TypeDef *pRTMR)
 {
-	pRTMR->CTL |= 1 << bsRTMR_CTL_TMR_EN;
+    pRTMR->CTL |= 1 << bsRTMR_CTL_TMR_EN;
 }
 
 void RTMR_Disable(RTMR_TypeDef *pRTMR)
 {
-	pRTMR->CTL &= ~(1 << bsRTMR_CTL_TMR_EN);
+    pRTMR->CTL &= ~(1 << bsRTMR_CTL_TMR_EN);
 }
 
-//
 void RTMR_SetOpMode(RTMR_TypeDef *pRTMR, uint8_t mode)
 {
-   #define mask (2 << bsRTMR_CTL_OP_MODE)
-   pRTMR->CTL = (pRTMR->CTL & ~mask) | (mode << bsRTMR_CTL_OP_MODE);
+    #define mask (2 << bsRTMR_CTL_OP_MODE)
+    pRTMR->CTL = (pRTMR->CTL & ~mask) | (mode << bsRTMR_CTL_OP_MODE);
 }
 
-//
 void RTMR_IntEnable(RTMR_TypeDef *pRTMR)
 {
-	pRTMR->CTL |= (1 << bsRTMR_CTL_INT_EN);
+    pRTMR->CTL |= (1 << bsRTMR_CTL_INT_EN);
 }
 
 void RTMR_IntDisable(RTMR_TypeDef *pRTMR)
 {
-	pRTMR->CTL &= ~(1 << bsRTMR_CTL_INT_EN);
+    pRTMR->CTL &= ~(1 << bsRTMR_CTL_INT_EN);
 }
 
 void RTMR_IntClr(RTMR_TypeDef *pTMR)
 {
-	pTMR->CTL |= 1 << bsRTMR_CTL_INT_STATUS;
+    pTMR->CTL |= 1 << bsRTMR_CTL_INT_STATUS;
 }
 
 uint8_t RTMR_IntHappened(RTMR_TypeDef *pTMR)
 {
-	return ( (pTMR->CTL >> bsRTMR_CTL_INT_STATUS) & BW2M(bsRTMR_CTL_INT_STATUS) );
+    return ( (pTMR->CTL >> bsRTMR_CTL_INT_STATUS) & BW2M(bsRTMR_CTL_INT_STATUS) );
 }
 
 #endif

--- a/src/FWlib/peripheral_uart.c
+++ b/src/FWlib/peripheral_uart.c
@@ -289,7 +289,7 @@ uint8_t UART_ReceData(UART_TypeDef* pBase)
     return pBase->DataRead;
 }
 
-#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916 || INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 void UART_DmaEnable(UART_TypeDef *pBase, uint8_t tx_enable, uint8_t rx_enable, uint8_t dma_on_err)
 {
     pBase->DmaCon = rx_enable | (tx_enable << 1) | (dma_on_err << 2);

--- a/src/FWlib/peripheral_uart.h
+++ b/src/FWlib/peripheral_uart.h
@@ -354,7 +354,7 @@ void UART_SendData(UART_TypeDef* pBase, uint8_t Data);
 uint8_t UART_ReceData(UART_TypeDef* pBase);
 void uart_reset(UART_TypeDef* pBase);
 
-#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916 || INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 /**
  * @brief Enable/Disable DMA transfer
  * @param[in] pBase                 base address

--- a/src/StartUP/ing20/ingsoc.h
+++ b/src/StartUP/ing20/ingsoc.h
@@ -326,7 +326,8 @@ typedef struct{
     __IO uint32_t sadc_cfg[3];            // 0x0
     __IO uint32_t sadc_data;              // 0x0c
     __IO uint32_t sadc_status;            // 0x10
-    __IO uint32_t Reserved[7];            // 0x14
+    __IO uint32_t sadc_cfg3;              // 0x14
+    __IO uint32_t Reserved[6];            // 0x18
     __IO uint32_t sadc_int_mask;          // 0x30
     __IO uint32_t sadc_int;               // 0x34
 } SADC_TypeDef;
@@ -473,132 +474,129 @@ typedef struct
 
 typedef struct
 {
-    __IO uint32_t      reg_task[6];         //0x000
-    __IO uint32_t      _NOT_USED_1[2];         //0x01c
-    __IO uint32_t      reg_sub_task[6];     //0x020
-    __IO uint32_t      _NOT_USED_2[2];         //0x03c
-    __IO uint32_t      reg_event;           //0x040
-    __IO uint32_t      reg_pub_event[3];    //0x044
+    __IO uint32_t      reg_task[6];
+    __IO uint32_t      _NOT_USED_1[2];
+    __IO uint32_t      reg_sub_task[6];
+    __IO uint32_t      _NOT_USED_2[2];
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event[3];
 }PTE_QDEC_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_event;           //0x050
-    __IO uint32_t      reg_pub_event[8];    //0x054
-    __IO uint32_t      _NOT_USED_3[3];         //0x074
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event[8];
+    __IO uint32_t      _NOT_USED_3[3];
 }PTE_DMA_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[24];         //0x080
-    __IO uint32_t      reg_sub_task[24];         //0x0f0
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event[8];         //0x164
+    __IO uint32_t      reg_task[24];
+    __IO uint32_t      reg_sub_task[24];
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event[8];
     __IO uint32_t      _NOT_USED[3];
 }PTE_GPIOTE_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[16];         //0x0170
-    __IO uint32_t      reg_sub_task[16];         //0x160
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event[8];         //0x164
+    __IO uint32_t      reg_task[16];
+    __IO uint32_t      reg_sub_task[16];
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event[8];
     __IO uint32_t      _NOT_USED[3];
 }PTE_Timer_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[2];         //0x220
-    __IO uint32_t      reg_sub_task[2];         //0x160
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event0;         //0x164
+    __IO uint32_t      reg_task[2];
+    __IO uint32_t      reg_sub_task[2];
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event0;
     __IO uint32_t      _NOT_USED[2];
 }PTE_QSPI_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task0;         //0x240
-    __IO uint32_t      reg_sub_task0;         //0x160
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event0;         //0x164
+    __IO uint32_t      reg_task0;
+    __IO uint32_t      reg_sub_task0;
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event0;
 }PTE_I2C_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[3];         //0x250
+    __IO uint32_t      reg_task[3];
     __IO uint32_t      _NOT_USED;
-    __IO uint32_t      reg_sub_task[3];         //0x260
+    __IO uint32_t      reg_sub_task[3];
     __IO uint32_t      _NOT_USED1;
-    __IO uint32_t      reg_event;           //0x270
-    __IO uint32_t      reg_pub_event[2];         //0x164
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event[2];
     __IO uint32_t      _NOT_USED2;
 }PTE_SADC_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[4];         //0x280
-    __IO uint32_t      reg_sub_task[4];         //0x160
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event[2];         //0x164
+    __IO uint32_t      reg_task[4];
+    __IO uint32_t      reg_sub_task[4];
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event[2];
     __IO uint32_t      _NOT_USED;
 }PTE_Uart_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[2];         //0x2e0
-    __IO uint32_t      reg_sub_task[2];         //0x160
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event0;         //0x164
+    __IO uint32_t      reg_task[2];
+    __IO uint32_t      reg_sub_task[2];
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event0;
     __IO uint32_t      _NOT_USED[2];
 }PTE_SPI_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[21];         //0x300
+    __IO uint32_t      reg_task[21];
     __IO uint32_t      _NOT_USED0[3];
-    __IO uint32_t      reg_sub_task[21];         //0x160
+    __IO uint32_t      reg_sub_task[21];
     __IO uint32_t      _NOT_USED1[3];
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event[9];         //0x164
+    __IO uint32_t      reg_event;
+    __IO uint32_t      reg_pub_event[9];
     __IO uint32_t      _NOT_USED2[2];
 }PTE_PWM_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task[4];         //0x4a0
-    __IO uint32_t      reg_sub_task[4];         //0x160
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event0;         //0x164
+    __IO uint32_t      reg_task[4];
+    __IO uint32_t      reg_sub_task[4];
 }PTE_I2S_TypeDef;
 
 typedef struct
 {
-    __IO uint32_t      reg_task0;         //0x3f0
-    __IO uint32_t      reg_sub_task0;         //0x160
-    __IO uint32_t      reg_task1;         //0x0f0
-    __IO uint32_t      reg_sub_task1;         //0x160
-    __IO uint32_t      reg_event;           //0x160
-    __IO uint32_t      reg_pub_event0;         //0x164
+    __IO uint32_t      reg_task0;
+    __IO uint32_t      reg_sub_task0;
+    __IO uint32_t      reg_task1;
+    __IO uint32_t      reg_sub_task1;
+    __IO uint32_t      reg_event;
+    __IO uint32_t      _NOT_USED1[8];
+    __IO uint32_t      reg_pub_event0;
 }PTE_ASDM_TypeDef;
-
-
 
 typedef struct
 {
-    PTE_QDEC_TypeDef 	PTE_QDEC;
-    PTE_DMA_TypeDef 	PTE_DMA;
-    PTE_GPIOTE_TypeDef 	PTE_GPIOTE;
-    PTE_Timer_TypeDef 	PTE_TIMER0;
-    PTE_QSPI_TypeDef 	PTE_QSPI;
-    PTE_I2C_TypeDef 	PTE_I2C;
-    PTE_SADC_TypeDef 	PTE_SADC;
-    PTE_Uart_TypeDef 	PTE_UART0;
-    PTE_Uart_TypeDef 	PTE_UART1;
-    PTE_SPI_TypeDef 	PTE_SPI;
-    PTE_PWM_TypeDef 	PTE_PWM;
-    PTE_Timer_TypeDef 	PTE_TIMER1;
-    PTE_I2S_TypeDef 	PTE_I2S;
-    PTE_ASDM_TypeDef 	PTE_ASDM;
+    PTE_QDEC_TypeDef    PTE_QDEC;
+    PTE_DMA_TypeDef     PTE_DMA;
+    PTE_GPIOTE_TypeDef  PTE_GPIOTE;
+    PTE_Timer_TypeDef   PTE_TIMER0;
+    PTE_QSPI_TypeDef    PTE_QSPI;
+    PTE_I2C_TypeDef     PTE_I2C;
+    PTE_SADC_TypeDef    PTE_SADC;
+    PTE_Uart_TypeDef    PTE_UART0;
+    PTE_Uart_TypeDef    PTE_UART1;
+    PTE_SPI_TypeDef     PTE_SPI;
+    PTE_PWM_TypeDef     PTE_PWM;
+    PTE_Timer_TypeDef   PTE_TIMER1;
+    PTE_I2S_TypeDef     PTE_I2S;
+    PTE_ASDM_TypeDef    PTE_ASDM;
 }PTE_BUS_TypeDef;
 
 typedef struct
@@ -661,6 +659,7 @@ typedef struct
 #define APB_ASDM_BASE      (APB_BASE + 0x1a000)
 #define APB_TMR2_BASE      (APB_BASE + 0x1c000)
 #define APB_TMR3_BASE      (APB_BASE + 0x1c010)
+#define APB_GPIOTE_BASE    (APB_BASE + 0x001f0)
 
 #define AON_APB_BASE       ((uint32_t)0x40100000UL)
 #define AON2_CTRL_BASE     (AON_APB_BASE + 0x0000)
@@ -694,6 +693,7 @@ typedef struct
 #define APB_PTE            ((PTEC_TypeDef *)APB_PTE_BASE)
 #define APB_PTE_BUS        ((PTE_BUS_TypeDef *)APB_PTE_BUS_BASE)
 #define APB_ASDM           ((ASDM_TypeDef *)APB_ASDM_BASE)
+#define APB_GPIOTE         ((GPIOTE_TypeDef *)APB_GPIOTE_BASE)
 
 #define APB_SPI            APB_SSP1
 #define AHB_QSPI           AHB_SSP0


### PR DESCRIPTION
- ingsoc.h: Add missing register definitions and correct existing register errors
- adc: Remove unsupported features and simplify interface, making it incompatible with 916
- asdm: Modify default parameters for high-pass filter to resolve over-suppression issue
- DMA: Fix missing return error caused by interface merging
- gpio: Add missing GroupA setting interface
- keysan: Refactor key value parsing code
- PTE: Refactor configuration interface and add GPIOTE interface
- Sysctrl: Add RC trim functionality
- uart dma: Add DMA interface macro parameters for 20 series