### PR TITLE
Fix bug and add feature

### DIFF
--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -886,9 +886,10 @@ uint32_t ADC_PopFifoData(void)
 {
     return ADC_RegRd(SADC_DATA, 0, 18);
 }
+
 SADC_channelId ADC_GetDataChannel(const uint32_t data)
 {
-    return (SADC_channelId)(ADC_RIGHT_SHIFT(data, 14) & ADC_MK_MASK(4));
+    return (SADC_channelId)(ADC_RIGHT_SHIFT(data, 12) & ADC_MK_MASK(4));
 }
 
 uint16_t ADC_GetData(const uint32_t data)
@@ -928,7 +929,11 @@ void ADC_HardwareCalibration(void)
         for (uint32_t j = 0; j < 100; j++) __NOP();
         rwData = APB_SADC->sadc_cfg3;
     }
-    ADC_RegWrBits(SADC_CFG_2, 0, 3, 12);
+    ADC_RegClr(SADC_CFG_2, 3, 12);
+    ADC_RegClr(SADC_CFG_2, 0, 1);
+    while (ADC_GetBusyStatus());
+    ADC_RegClr(SADC_CFG_0, 1, 1);
+    APB_SADC->sadc_int_mask = 0;
 }
 
 void ADC_Reset(void)
@@ -942,7 +947,11 @@ void ADC_Reset(void)
     ADC_RegClr(SADC_INT_MAKS, 0, 32);
 
     ADC_RegWr(SADC_CFG_0, 1, 28);
-    ADC_RegWrBits(SADC_CFG_2, 0, 3, 12);
+    ADC_RegClr(SADC_CFG_2, 3, 12);
+    ADC_RegClr(SADC_CFG_2, 0, 1);
+    while (ADC_GetBusyStatus());
+    ADC_RegClr(SADC_CFG_0, 1, 1);
+    APB_SADC->sadc_int_mask = 0;
 }
 
 void ADC_Start(uint8_t start)
@@ -955,7 +964,6 @@ void ADC_Start(uint8_t start)
         while (ADC_GetBusyStatus());
     }
 }
-
 
 void ADC_SetVref(SADC_Vref vref)
 {

--- a/src/FWlib/peripheral_adc.h
+++ b/src/FWlib/peripheral_adc.h
@@ -680,12 +680,9 @@ void ADC_SetVref(SADC_Vref vref);
  * @brief ADC conversion standard configuration interface
  *
  * @param[in] ctrlMode       ADC control mode, see 'SADC_adcCtrlMode'
- * @param[in] pgaPara        pga-para, see 'SADC_pgaPara'
- * @param[in] pgaEnable      enable/diable pga
  * @param[in] ch             ADC channel id, see 'SADC_channelId'
- * @param[in] enNum          ADC interrupt trigger number(0-15)
- * @param[in] dmaEnNum       DMA transmition require trigger number(0-15)
- * @param[in] inputMode      ADC input mode, see 'SADC_adcIputMode'
+ * @param[in] enNum          ADC interrupt trigger number(0-4)
+ * @param[in] dmaEnNum       DMA transmition require trigger number(0-4)
  * @param[in] loopDelay      ADC loop delay(0-0xffffffff)
  */
 void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2197,6 +2197,19 @@ void SYSCTRL_SetAdcVrefSel(uint8_t val)
         set_reg_bit((volatile uint32_t*)(APB_SYSCTRL_BASE + 0x234), 1, 8);
 }
 
+void SYSCTRL_EnableResetSource(uint8_t enable)
+{
+    set_reg_bit((volatile uint32_t*)(APB_SYSCTRL_BASE + 0x218), enable, 0);
+}
+
+SYSCTRL_ResetSource SYSCTRL_GetResetSource(void)
+{
+    uint32_t val;
+    val = *(volatile uint32_t*)(APB_SYSCTRL_BASE + 0x218);
+
+    return (val>>1)&0x3f;
+}
+
 #endif
 
 void SYSCTRL_DelayCycles(uint32_t freq, uint32_t cycles)

--- a/src/FWlib/peripheral_sysctrl.h
+++ b/src/FWlib/peripheral_sysctrl.h
@@ -1261,6 +1261,28 @@ typedef enum
 } SYSCTRL_ClkMode;
 
 /**
+ * @brief Get system rest source
+ *
+ * SYSCTRL_RESET_PDR: PDR module tigger reset.
+ * SYSCTRL_RESET_PVD: PVD module tigger reset.
+ * SYSCTRL_RESET_GLOBAL_SOFT: register reset is set.
+ * SYSCTRL_RESET_CPU: CPU core reset.
+ * SYSCTRL_RESET_PIN: Pressing the external reset button.
+ * SYSCTRL_RESET_WDT: Watchdog timeout.
+ * SYSCTRL_RESET_POR: Power on reset or feature is note open.
+ */
+typedef enum
+{
+    SYSCTRL_RESET_PDR = 0x4,
+    SYSCTRL_RESET_PVD = 0x8,
+    SYSCTRL_RESET_GLOBAL_SOFT = 0x10,
+    SYSCTRL_RESET_CPU = 0x20,
+    SYSCTRL_RESET_PIN = 0x31,
+    SYSCTRL_RESET_WDT = 0x32,
+    SYSCTRL_RESET_POR = 0x3f,
+} SYSCTRL_ResetSource;
+
+/**
  * @brief Select clock mode of TIMER
  *
  * All timers share the same clock divider, which means that if timer K is
@@ -2018,6 +2040,32 @@ void SYSCTRL_SetFastPreDiv(uint8_t div);
  * @brief current FastPreCLK(Fast Peripheral CLK) in Hz.
  */
 uint32_t SYSCTRL_GetFastPreCLK(void);
+
+/**
+ * @brief Set Qdec pclk divider
+ * @param[in]   div             divider
+ */
+void SYSCTRL_UpdateQdecClk(uint32_t div);
+
+/**
+ * @brief Enable feature for getting the current reset source.
+ *
+ * @param[in] enable 1 : enable 0: disable
+ *
+ * @note When this feature is enabled, the reset cause recording module will be reset;
+ * therefore, the reset cause from the previous reset must be read prior to enabling this feature.
+ */
+void SYSCTRL_EnableResetSource(uint8_t enable);
+
+/**
+ * @brief Get reset source.
+ * You can determine the previous reset cause
+ * by checking the return value of this function during system startup.
+ * The reset cause is one of the values from the 'SYSCTRL_ResetSource' enumeration.
+ *
+ * @return reset source.
+ */
+SYSCTRL_ResetSource SYSCTRL_GetResetSource(void);
 
 
 #endif


### PR DESCRIPTION
feature: Add chip reset cause retrieval functionality

fix: Restore default register state after ADC reset and ADC_HardwareCalibration
- Fix issue where registers were not restored to default state after ADC reset and hardware calibration

fix: Correct channel data acquisition in ADC_GetDataChannel function
- Fix abnormal data retrieval issue in ADC_GetDataChannel function

fix: Revert erroneous modification to SYSCTRL_GetFlashClk function
- Fix functional abnormality introduced in previous version update

fix: Add missing SYSCTRL_UpdateQdecClk declaration
- Add missing function declaration for SYSCTRL_UpdateQdecClk