### PR TITLE
feat: implement KV/QDEC v20 features and fix multiple driver issues

### DIFF
--- a/examples/hid_keyboard/src/kv_impl.c
+++ b/examples/hid_keyboard/src/kv_impl.c
@@ -106,6 +106,18 @@ static void kv_do_backup(uint32_t from, uint32_t to)
             from += sizeof(buf);
             to += sizeof(buf);
         }
+#elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+        int i;
+        uint32_t buf[16];
+        erase_flash_sector(to);
+
+        for (i = 0; i < BLOCK_SIZE / sizeof(buf); i++)
+        {
+            memcpy(buf, (void *)from, sizeof(buf));
+            write_flash(to, (uint8_t *)buf, sizeof(buf));
+            from += sizeof(buf);
+            to += sizeof(buf);
+        }
 #endif
 }
 
@@ -114,6 +126,8 @@ static void kv_reset(void)
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
     erase_flash_page(DB_FLASH_ADDRESS);
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
+    erase_flash_sector(DB_FLASH_ADDRESS);
+#elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
     erase_flash_sector(DB_FLASH_ADDRESS);
 #endif
     kv_storage_tail = DB_FLASH_ADDRESS;

--- a/src/FWlib/peripheral_dma.c
+++ b/src/FWlib/peripheral_dma.c
@@ -620,6 +620,8 @@ static DMA_TransferWidth DMA_GetPeripheralWidth(SYSCTRL_DMA src)
         case SYSCTRL_DMA_UART0_TX:
         case SYSCTRL_DMA_UART1_TX:
             return DMA_WIDTH_BYTE;
+        case SYSCTRL_DMA_SADC:
+            return DMA_WIDTH_16_BITS;
 
         case SYSCTRL_DMA_SPI0_TX:
         case SYSCTRL_DMA_SPI0_RX:
@@ -663,7 +665,8 @@ static volatile void *DMA_GetPeripheralDataAddr(SYSCTRL_DMA src)
             return 0;
         case SYSCTRL_DMA_I2S_RX:
             return &APB_I2S->RX;
-
+        case SYSCTRL_DMA_SADC:
+            return &APB_SADC->sadc_data;
         case SYSCTRL_DMA_UART0_TX:
             return &APB_UART0->DataRead;
         case SYSCTRL_DMA_UART1_TX:

--- a/src/FWlib/peripheral_i2c.h
+++ b/src/FWlib/peripheral_i2c.h
@@ -436,7 +436,11 @@ uint8_t GET_I2C_DEBUG0_DMAREQ(I2C_TypeDef *I2C_BASE);
 
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916) || (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
 #define I2C_FIFO_DEPTH      8
+#elif  (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+#define I2C_FIFO_DEPTH      4
+#endif
 
 typedef enum
 {
@@ -462,6 +466,7 @@ typedef enum
 {
     I2C_STATUS_FIFO_EMPTY = 0,
     I2C_STATUS_FIFO_FULL = 1,
+    I2C_STATUS_FIFO_HALF = 2,
     I2C_STATUS_ADDRHIT = 3, // indicates a transaction is addressed on this controller
     I2C_STATUS_CMPL = 9   , // indicates transaction completion
     I2C_STATUS_ACK  = 10  , // indicates the type of the last received/transmitted

--- a/src/FWlib/peripheral_i2s.h
+++ b/src/FWlib/peripheral_i2s.h
@@ -10,7 +10,11 @@ extern "C" {	/* allow C++ to use these headers */
 
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916 || INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
 #define I2S_FIFO_DEPTH      16
+#elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+#define I2S_FIFO_DEPTH      4
+#endif
 
 typedef enum
 {
@@ -179,12 +183,14 @@ int I2S_GetTxFIFOCount(I2S_TypeDef *base);
  */
 int I2S_GetRxFIFOCount(I2S_TypeDef *base);
 
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
 /**
  * @brief Enable/Disable data from PDM
  *
  * @param[in] enable                    Enable or disable(default)
  */
 void I2S_DataFromPDM(uint8_t enable);
+#endif
 
 #endif
 

--- a/src/FWlib/peripheral_pinctrl.c
+++ b/src/FWlib/peripheral_pinctrl.c
@@ -606,6 +606,8 @@ int PINCTRL_Pull(const uint8_t io_pin, const pinctrl_pull_mode_t mode)
 
 int PINCTRL_SetPadMux(const uint8_t io_pin_index, const io_source_t source)
 {
+    if (io_pin_index == IO_NOT_A_PIN)
+        return 0;
     int r = source_id_on_pin(io_pin_index, source);
     if (r < 0) return r;
 
@@ -1103,6 +1105,8 @@ int PINCTRL_KeyScanPullSel(const uint8_t io_pin, uint8_t enable)
 
 int PINCTRL_SetPadMux(const uint8_t io_pin_index, const io_source_t source)
 {
+    if (io_pin_index == IO_NOT_A_PIN)
+        return 0;
     int r = source_id_on_pin(io_pin_index, source);
     if (r < 0) return r;
 

--- a/src/FWlib/peripheral_qdec.c
+++ b/src/FWlib/peripheral_qdec.c
@@ -416,6 +416,26 @@ void QDEC_SetCHxTmrCntC(QDEC_CHX Channel, uint16_t val)
     APB_QDEC->channels[Channel].channel_write_c = val;
 }
 
+void QDEC_EnableInt(uint8_t mask)
+{
+    QDEC_SetRegBits(&APB_QDEC->qdec_inten, mask, 0, 4);
+}
+
+void QDEC_EnableDoubleEdge(uint8_t enable)
+{
+    QDEC_SetRegBits(&APB_QDEC->bmr, enable, 1, 12);
+}
+
+void QDEC_SetExternalTrigger(QDEC_CHX Channel, uint8_t val)
+{
+    QDEC_SetRegBits(&APB_QDEC->channels[Channel].channel_mode, val, 2, 10);
+}
+
+void QDEC_SetExternalTriggerEn(QDEC_CHX Channel, uint8_t enable)
+{
+    QDEC_SetRegBit(&APB_QDEC->channels[Channel].channel_mode, enable, 12);
+}
+
 void QDEC_SetChxIntEn(QDEC_CHX Channel, uint8_t enable, uint16_t items)
 {
 
@@ -519,7 +539,6 @@ void QDEC_IntClear(void)
 {
     QDEC_ReadRegBits(&APB_QDEC->channels[0].channel_tiob0_rd, 10, 0);
 }
-
 
 #endif
 

--- a/src/FWlib/peripheral_ssp.c
+++ b/src/FWlib/peripheral_ssp.c
@@ -343,7 +343,7 @@ void apSSP_WrtEnlargeEn(SSP_TypeDef *SPI_BASE, uint8_t enable)
 
 void apSSP_WrtEnlargeCnt(SSP_TypeDef *SPI_BASE, uint16_t cnt)
 {
-    SPI_BASE->IntrEn &= (~(BW2M(bsSPI_TRANSCTRL_WRENLARGECNT) << bsSPI_TRANSCTRL_WRENLARGECNT));
+    SPI_BASE->IntrEn &= (~(BW2M(bwSPI_TRANSCTRL_WRENLARGECNT) << bsSPI_TRANSCTRL_WRENLARGECNT));
     SPI_BASE->IntrEn |= ((0xffff & (cnt-1)) << bsSPI_TRANSCTRL_WRENLARGECNT);
 }
 #endif

--- a/src/FWlib/peripheral_ssp.h
+++ b/src/FWlib/peripheral_ssp.h
@@ -269,6 +269,7 @@ typedef enum
 #define bsSPI_TRANSCTRL_WRTRANCNT         12
 #if (INGCHIPS_FAMILY_20 == INGCHIPS_FAMILY)
 #define bsSPI_TRANSCTRL_WRENLARGECNT      8
+#define bwSPI_TRANSCTRL_WRENLARGECNT      16
 #endif
 /* SPI_TransCtrl_DualQuad_e */
 #define bsSPI_TRANSCTRL_DUALQUAD          22
@@ -832,6 +833,38 @@ void apSSP_SetTransferControlAddrFmt(SSP_TypeDef *SPI_BASE, SPI_TransCtrl_AddrFm
  * @param[in] cmd                   refer to apSSP_sDeviceMemRdCmd for different cmd format
  */
 void apSSP_SetMemAccessCmd(SSP_TypeDef *SPI_BASE, apSSP_sDeviceMemRdCmd cmd);
+
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+
+/**
+ * @brief SPI long data write feature enabled (greater than 512 counts)
+ *
+ * @note If enable this feature, 'apSSP_SetTransferControlWrTranCnt' change to 'apSSP_WrtEnlargeCnt'
+ *
+ * @param[in] SPI_BASE              base address
+ * @param[in] enable                enable long cnt mode
+ */
+void apSSP_WrtEnlargeEn(SSP_TypeDef *SPI_BASE, uint8_t enable);
+
+/**
+ * @brief SPI long data write cnt (greater than 512 counts)
+ *
+ * @note If enable this feature, 'apSSP_SetTransferControlWrTranCnt' change to 'apSSP_WrtEnlargeCnt'
+ *
+ * @param[in] SPI_BASE              base address
+ * @param[in] val                   write cnt number for one spi transfer(CS down and up)
+ */
+void apSSP_WrtEnlargeCnt(SSP_TypeDef *SPI_BASE, uint16_t cnt);
+
+#endif
+
+/**
+ * @brief Get spi status
+ *
+ * @param[in] SPI_BASE              base address, only apply to SPI0
+ * @param[out] status
+ */
+uint32_t apSSP_GetStatus(SSP_TypeDef *SPI_BASE);
 #endif
 
 #ifdef __cplusplus

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -1258,7 +1258,7 @@ static void SYSCTRL_ClkGateCtrl(SYSCTRL_ClkGateItem item, uint8_t v)
         set_reg_bit(APB_SYSCTRL->CguCfg + 5, v, 10);
         break;
     case SYSCTRL_ITEM_APB_QDEC      :
-        set_reg_bit(APB_SYSCTRL->CguCfg + 4, v, 9);
+        set_reg_bit(APB_SYSCTRL->CguCfg + 3, v, 9);
         set_reg_bit(&APB_SYSCTRL->QdecCfg, v, 12);
         break;
     case SYSCTRL_ITEM_APB_KeyScan   :
@@ -1886,7 +1886,7 @@ uint32_t SYSCTRL_GetFastPreCLK(void)
 uint32_t SYSCTRL_GetFlashClk()
 {
     if (*AON1_REG5 & (1ul << 31))
-        return SYSCTRL_GetPLLClk() / get_safe_divider(APB_SYSCTRL->CguCfg[0], 24, 4);
+        return SYSCTRL_GetPLLClk() / get_safe_divider(*AON1_REG5, 24, 4);
 
     return SYSCTRL_GetSlowClk();
 }
@@ -2037,6 +2037,7 @@ int SYSCTRL_Init(void)
 
     set_reg_bit((volatile uint32_t *)(AON2_CTRL_BASE + 0x4),0,18);
     set_reg_bit((volatile uint32_t *)(AON1_CTRL_BASE + 0x14),0,26);
+    set_reg_bit((volatile uint32_t *)(AON1_CTRL_BASE + 0x10),0,10);
 
     // TODO:
     return 0;

--- a/src/FWlib/peripheral_timer.c
+++ b/src/FWlib/peripheral_timer.c
@@ -291,7 +291,7 @@ void TMR_WatchDogDisable(void)
 {
     WDT_UNLOCK();
     APB_WDT->Ctrl = 0;
-    *AON1_BOOT &= ~(1u << 28);
+    *AON1_BOOT &= ~(1u << 22);
 }
 
 void TMR_WatchDogRestart()


### PR DESCRIPTION
Add KV_IMPL v20 feature support
Set default SADC bit width in DMA to fix ADC-DMA malfunction Adjust I2S FIFO depth default value
Fix PINCTRL_SetPadMux error when using IO_NOT_A_PIN for SPI pins Add placeholder implementations for QDEC v20xx ignored functions Fix SPI data transmission failure for payloads >512 bytes Revert incorrect change in SYSCTRL_GetFlashClk
Resolve occasional QDEC register write failure
Disable AON1 pin wakeup source by default to prevent spurious wakeups from Type-A IO inputs Fix WDT disable configuration issue