### PR TITLE
Dev jzh

### DIFF
--- a/examples/peripheral_battery/src/main.c
+++ b/examples/peripheral_battery/src/main.c
@@ -242,6 +242,8 @@ void setup_peripherals(void)
     SYSCTRL_SetAdcClkDiv(4);
     SYSCTRL_ReleaseBlock(SYSCTRL_ITEM_APB_ADC);
     ADC_Reset();
+    ADC_HardwareCalibration();
+    ADC_SetVref(VREF_OUT_MODE);
 #endif
 #else
     #error unknown or unsupported chip family
@@ -255,7 +257,6 @@ uint32_t timer_isr(void *user_data);
 void ADC_ClearChannelDataValid(const uint8_t channel_id) { }
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 void ADC_ClearChannelDataValid(const uint8_t channel_id) { }
-uint16_t ADC_ReadChannelData(const uint8_t channel_id) { return 0;}
 #endif
 
 const platform_evt_cb_table_t evt_cb_table =

--- a/examples/peripheral_battery/src/profile.c
+++ b/examples/peripheral_battery/src/profile.c
@@ -183,9 +183,6 @@ uint16_t read_adc(uint8_t channel)
     ADC_AveDisable();
     return sample;
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
-    ADC_Reset();
-    ADC_HardwareCalibration();
-    ADC_SetVref(VREF_LDO33_MODE);
     ADC_ConvCfg(CONTINUES_MODE, (SADC_channelId)channel, AVE_NUM, 0, LOOP_DELAY(ADC_CLK_MHZ, SAMPLERATE, ADC_CH_NUM));
     ADC_AveInit();
     ADC_Start(1);

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -788,9 +788,10 @@ static uint16_t calc_factory_calib_crc16(const factory_calib_data_t *calib)
 
 static void copy_security_bytes(uint8_t *dst, uint32_t src, uint32_t size)
 {
+    uint32_t word;
     while (size >= 4U)
     {
-        uint32_t word = read_flash_security(src);
+        word = read_flash_security(src);
         memcpy(dst, &word, sizeof(word));
         dst += sizeof(word);
         src += sizeof(word);
@@ -799,7 +800,7 @@ static void copy_security_bytes(uint8_t *dst, uint32_t src, uint32_t size)
 
     if (size > 0U)
     {
-        uint32_t word = read_flash_security(src);
+        word = read_flash_security(src);
         memcpy(dst, &word, size);
     }
 }
@@ -921,8 +922,13 @@ int flash_prepare_factory_data(void)
     
     flash_read_protection_status(&region, &reverse_selection);
     flash_enable_write_protection(FLASH_REGION_NONE, 0);
-    
-    erase_flash_sector(FACTORY_DATA_LOC);
+
+    if(read_flash_security(FACTORY_DIE_INFO_SRC_ADDR) == 0xfffffffful)
+    {
+        // no ft data;
+        flash_enable_write_protection((flash_region_t)region, reverse_selection);
+        return 1;
+    }
 
     copy_security_bytes((uint8_t *)&die_info,
                         FACTORY_DIE_INFO_SRC_ADDR,
@@ -933,10 +939,11 @@ int flash_prepare_factory_data(void)
 
     uint16_t crc = calc_factory_info_crc16(&die_info);
     if (crc != die_info.info_crc16)
-        return 1;
+        goto check_failed;
     crc = calc_factory_calib_crc16(&calib);
     if (crc != die_info.trim_crc16)
-        return 2;
+        goto check_failed;
+    erase_flash_sector(FACTORY_DATA_LOC);
 
     if (write_flash(FACTORY_DATA_LOC,
                     (const uint8_t *)&die_info,

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -598,9 +598,6 @@ void flash_read_uid(uint32_t uid[4])
 
 typedef void (* f_void)(void);
 typedef void (* f_prog_page)(uint32_t addr, const uint8_t data[256], uint32_t len);
-typedef int (* f_erase_flash_sector)(uint32_t addr);
-typedef int (* f_program_flash)(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size);
-typedef int (* f_write_flash)(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size);
 typedef int (* f_flash_do_update)(const int block_num, const fota_update_block_t *blocks, uint8_t *ram_buffer);
 
 typedef void (*rom_void_void)(void);
@@ -610,9 +607,6 @@ typedef void (*rom_FlashWriteStatusReg)(uint16_t data);
 typedef uint8_t (*rom_FlashReadReg)(uint8_t cmd);
 typedef uint32_t (*rom_FlashSecurityPageRead)(uint32_t addr);
 
-#define ROM_erase_flash_sector              ((f_erase_flash_sector)0x00008977)
-#define ROM_program_flash                   ((f_program_flash)0x00025de5)
-#define ROM_write_flash                     ((f_write_flash)0x0002bbe9)
 #define ROM_flash_do_update                 ((f_flash_do_update)0x00008eb9)
 
 #define ROM_FlashSectorErase                ((rom_FlashSectorErase)0x000007a1)
@@ -626,9 +620,12 @@ typedef uint32_t (*rom_FlashSecurityPageRead)(uint32_t addr);
 #define ROM_FlashWriteStatusReg             ((rom_FlashWriteStatusReg)(0x00000b71))
 #define read_flash_security                 ((rom_FlashSecurityPageRead)(0x00000a4d))
 
+#define FLASH_PROGRAM_CHUNK_SIZE            32u
+
 #define FLASH_PRE_OPS()                         \
-    uint32_t prim = __get_PRIMASK();            \
-    uint8_t mode = 0;                           \
+    uint32_t prim;              \
+    uint8_t mode = 0; \
+    prim =  __get_PRIMASK();  \
     __disable_irq();                            \
     if (IS_CONTINUOUS_MODE()) {                 \
         mode = 1;                               \
@@ -638,6 +635,27 @@ typedef uint32_t (*rom_FlashSecurityPageRead)(uint32_t addr);
 #define FLASH_POST_OPS()                    \
     if (mode) ROM_FlashEnableContinuousMode(); \
     if (!prim) __enable_irq()
+
+static inline void flash_program_write(uint32_t dest_addr, const uint8_t *buffer, uint32_t len)
+{
+    uint32_t chunk;
+#if (FLASH_PROGRAM_WITH_DMA == 1)
+    uint32_t reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18))&(0x1<<31);
+
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1<<31);
+    ROM_FlashPageProgram(0x02, dest_addr, buffer, len);
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1<<31);
+#else
+    while (len > 0u)
+    {
+        chunk = (len > FLASH_PROGRAM_CHUNK_SIZE) ? FLASH_PROGRAM_CHUNK_SIZE : len;
+        ROM_FlashPageProgram(0x02, dest_addr, buffer, chunk);
+        dest_addr += chunk;
+        buffer += chunk;
+        len -= chunk;
+    }
+#endif
+}
 
 int erase_flash_sector(const uint32_t addr)
 {
@@ -662,23 +680,21 @@ int program_flash(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
     if (dest_addr & (EFLASH_SECTOR_SIZE - 1)) return -1;
 
     FLASH_PRE_OPS();
+    while (size > 0)
     {
-        while (size > 0)
+        uint32_t remain = EFLASH_SECTOR_SIZE;
+
+        ROM_FlashSectorErase(0x20, dest_addr);
+
+        while ((remain > 0) && (size > 0))
         {
-            uint32_t remain = EFLASH_SECTOR_SIZE;
-
-            ROM_FlashSectorErase(0x20, dest_addr);
-
-            while ((remain > 0) && (size > 0))
-            {
-                uint32_t cnt = size > EFLASH_PAGE_SIZE ? EFLASH_PAGE_SIZE : size;
-                cnt = cnt > remain ? remain : cnt;
-                ROM_FlashPageProgram(0x02, dest_addr, buffer, cnt);
-                dest_addr += cnt;
-                buffer += cnt;
-                remain -= cnt;
-                size -= cnt;
-            }
+            uint32_t cnt = size > EFLASH_PAGE_SIZE ? EFLASH_PAGE_SIZE : size;
+            cnt = cnt > remain ? remain : cnt;
+            flash_program_write(dest_addr, buffer, cnt);
+            dest_addr += cnt;
+            buffer += cnt;
+            remain -= cnt;
+            size -= cnt;
         }
     }
     SYSCTRL_ICacheFlush();
@@ -696,22 +712,21 @@ int write_flash(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
         if ((*(const uint8_t *)(dest_addr + i) & buffer[i]) != buffer[i])
             return 1;
     }
-
+    
     FLASH_PRE_OPS();
+
+    while (size > 0)
     {
-        while (size > 0)
-        {
-            uint32_t block = next_page - dest_addr;
-            if (block >= size) block = size;
+        uint32_t block = next_page - dest_addr;
+        if (block >= size) block = size;
 
-            ROM_FlashPageProgram(0x02, dest_addr, buffer, block);
-
-            dest_addr += block;
-            buffer += block;
-            size -= block;
-            next_page += EFLASH_PAGE_SIZE;
-        }
+        flash_program_write(dest_addr, buffer, block);
+        dest_addr += block;
+        buffer += block;
+        size -= block;
+        next_page += EFLASH_PAGE_SIZE;
     }
+    
     SYSCTRL_ICacheFlush();
     FLASH_POST_OPS();
     return 0;
@@ -724,6 +739,9 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
     {
         ROM_FlashEnableContinuousMode();
     }
+    
+    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1<<31);
+    
     int r = ROM_flash_do_update(block_num, blocks, page_buffer);
     SYSCTRL_ICacheFlush();
     if (0 == is_continuous)
@@ -733,7 +751,7 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
     return r;
 }
 
-uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
+static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
     uint16_t crc = 0xFFFF;
     while (usDataLen--) {
         crc ^= *puchMsg++;
@@ -755,12 +773,6 @@ uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
 #define FACTORY_DATA_CALIB             (FACTORY_DATA_LOC + 0x100)
 #define FACTORY_DATA_CLC               (FACTORY_DATA_LOC + 0x200)
 #define ADC_CAL_CHANNEL_NUM            9
-#define ADC_PHY_INT_POINT0             0.3f
-#define ADC_PHY_INT_POINT1             1.0f
-#define ADC_PHY_VBAT_POINT0            0.5f
-#define ADC_PHY_VBAT_POINT1            2.7f
-#define ADC_PHY_VBAT_33                3.3f
-#define ADC_PHY_VBAT_25                2.5f
 
 
 static uint16_t calc_factory_info_crc16(const die_info_t *info)
@@ -802,16 +814,15 @@ static int factory_data_ready(void)
     return 1;
 }
 
-static int factory_clc_data_ready(const factory_clc_data_t *data)
+const factory_clc_data_t *flash_get_factory_clc_data(void)
 {
-    if (data == NULL)
+    const factory_clc_data_t *factory = (const factory_clc_data_t *)FACTORY_DATA_CLC;
+
+    if ((factory->magic_0 != FACTORY_DATA_MAGIC_0) ||
+        (factory->magic_1 != FACTORY_DATA_MAGIC_1))
         return 0;
 
-    if ((data->magic_0 != FACTORY_DATA_MAGIC_0) ||
-        (data->magic_1 != FACTORY_DATA_MAGIC_1))
-        return 0;
-
-    return data->version == FACTORY_CLC_DATA_VERSION;
+    return (const factory_clc_data_t *)FACTORY_DATA_CLC;
 }
 
 static void factory_set_linear_calib(adc_linear_calib_t *cal,
@@ -836,7 +847,7 @@ static void factory_set_vbat_calib(adc_vbat_calib_t *cal,
     const float x0 = (raw_vbat33 == 0U) ? 0.0f : (1.0f / (float)raw_vbat33);
     const float x1 = (raw_vbat25 == 0U) ? 0.0f : (1.0f / (float)raw_vbat25);
 
-    if ((cal == NULL) || (x0 == x1))
+    if ((cal == 0) || (raw_vbat33 == 0) || (raw_vbat25 == 0))
         return;
 
     cal->k = (vbat25 - vbat33) / (x1 - x0);
@@ -847,7 +858,7 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
 {
     int i;
 
-    if ((src == NULL) || (dst == NULL))
+    if ((src == 0) || (dst == 0))
         return;
 
     memset(dst, 0xff, sizeof(*dst));
@@ -858,23 +869,39 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
 
     for (i = 0; i < ADC_CAL_CHANNEL_NUM; ++i)
     {
-        factory_set_linear_calib(&dst->ch0_8_int_ref[i],
-                                 src->calib_adc.int_vbat33_ain0v3_ch0_8[i],
-                                 ADC_PHY_INT_POINT0,
-                                 src->calib_adc.int_vbat33_ain1v0_ch0_8[i],
-                                 ADC_PHY_INT_POINT1);
-        factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
-                                 src->calib_adc.vbat33_flt_ain0v5_ch0_8[i],
-                                 ADC_PHY_VBAT_POINT0,
-                                 src->calib_adc.vbat33_flt_ain2v7_ch0_8[i],
-                                 ADC_PHY_VBAT_POINT1);
+        if (i<2)
+        {
+            factory_set_linear_calib(&dst->ch0_8_int_ref[i],
+                                 src->calib_adc.int_vbat33_ain_ch0_8[i][0],
+                                 341.3333f,
+                                 src->calib_adc.int_vbat33_ain_ch0_8[i][1],
+                                 1137.7778f);
+            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
+                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
+                                     310.3030f,
+                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
+                                     1675.6364f);
+        }
+        else
+        {
+            factory_set_linear_calib(&dst->ch0_8_int_ref[i],
+                                     src->calib_adc.int_vbat33_ain_ch0_8[i][0],
+                                     682.6667f,
+                                     src->calib_adc.int_vbat33_ain_ch0_8[i][1],
+                                     2275.5556f);
+            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
+                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
+                                     620.6060f,
+                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
+                                     3351.2727f);
+        }
     }
 
     factory_set_vbat_calib(&dst->ch9_vbat,
                            src->calib_adc.vbat33_flt_int_ch9_11[0],
-                           ADC_PHY_VBAT_33,
+                           3.3f,
                            src->calib_adc.vbat25_flt_int_ch9_11[0],
-                           ADC_PHY_VBAT_25);
+                           2.5f);
 }
 
 int flash_prepare_factory_data(void)
@@ -883,14 +910,18 @@ int flash_prepare_factory_data(void)
     die_info_t die_info;
     uint8_t region;
     uint8_t reverse_selection;
+    factory_clc_data_t generated;
+    uint32_t reg_state;
 
     if (factory_data_ready())
         return 0;
+
+    reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18))&(0x1<<31);
     
     flash_read_protection_status(&region, &reverse_selection);
     flash_enable_write_protection(FLASH_REGION_NONE, 0);
     
-    ROM_FlashSectorErase(0x20, FACTORY_DATA_LOC);
+    erase_flash_sector(FACTORY_DATA_LOC);
 
     copy_security_bytes((uint8_t *)&die_info,
                         FACTORY_DIE_INFO_SRC_ADDR,
@@ -924,23 +955,31 @@ int flash_prepare_factory_data(void)
                sizeof(calib)) != 0)
         goto check_failed;
 
-    {
-        uint32_t magic[2];
+    flash_build_factory_clc_data(&calib, &generated);
 
-        magic[0] = FACTORY_DATA_MAGIC_0;
-        magic[1] = FACTORY_DATA_MAGIC_1;
-        if (write_flash(FACTORY_DATA_CLC,
-                        (const uint8_t *)magic,
-                        sizeof(magic)) != 0)
-            goto check_failed;
-    }
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1<<31);
+    if (write_flash(FACTORY_DATA_CLC,
+                    (const uint8_t *)&generated,
+                    sizeof(generated) - 8) != 0)
+        goto check_failed;
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1<<31);
+    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_CLC),
+               (const void *)&generated,
+               sizeof(generated) - 8) != 0)
+        goto check_failed;
+    if (write_flash(FACTORY_DATA_CLC + sizeof(generated) - 8,
+                    (const uint8_t *)&generated.magic_0,
+                    8) != 0)
+        goto check_failed;
 
     flash_enable_write_protection(region, reverse_selection);
     return 0;
 
 check_failed:
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1<<31);
     erase_flash_sector(FACTORY_DATA_LOC);
     flash_enable_write_protection(region, reverse_selection);
+    
     return 3;
 }
 
@@ -960,60 +999,6 @@ const factory_calib_data_t *flash_get_factory_calib_data(void)
     return NULL;
 }
 
-const factory_clc_data_t *flash_get_factory_clc_data(void)
-{
-    const factory_clc_data_t *data;
-    const factory_calib_data_t *calib;
-    factory_clc_data_t generated;
-
-    if (flash_prepare_factory_data() != 0)
-        return NULL;
-
-    data = (const factory_clc_data_t *)FACTORY_DATA_CLC;
-    if (factory_clc_data_ready(data))
-        return data;
-
-    calib = flash_get_factory_calib_data();
-    if (calib == NULL)
-        return NULL;
-
-    flash_build_factory_clc_data(calib, &generated);
-    if (flash_store_factory_clc_data(&generated) != 0)
-        return NULL;
-
-    data = (const factory_clc_data_t *)FACTORY_DATA_CLC;
-    return factory_clc_data_ready(data) ? data : NULL;
-}
-
-int flash_store_factory_clc_data(const factory_clc_data_t *data)
-{
-    uint8_t region;
-    uint8_t reverse_selection;
-
-    if (data == NULL)
-        return 1;
-
-    flash_read_protection_status(&region, &reverse_selection);
-    flash_enable_write_protection(FLASH_REGION_NONE, 0);
-
-    erase_flash_page(FACTORY_DATA_CLC);
-    if (write_flash(FACTORY_DATA_CLC,
-                    (const uint8_t *)data,
-                    sizeof(*data)) != 0)
-        goto store_failed;
-    if (memcmp((const void *)FACTORY_DATA_CLC,
-               (const void *)data,
-               sizeof(*data)) != 0)
-        goto store_failed;
-
-    flash_enable_write_protection(region, reverse_selection);
-    return 0;
-
-store_failed:
-    flash_enable_write_protection(region, reverse_selection);
-    return 2;
-}
-
 typedef void (* rom_FlashRUID)(uint32_t *UID);
 #define ROM_FlashRUID  ((rom_FlashRUID) (0x00000989))
 
@@ -1026,46 +1011,90 @@ void flash_read_uid(uint32_t uid[4])
     FLASH_POST_OPS();
 }
 
-int get_vaon(int target)
+int Vcore_calib(void)
 {
-    uint8_t i;
+    int i;
     uint8_t vcc_index;
+    uint32_t reg_data;
     const factory_calib_data_t * calib_data = flash_get_factory_calib_data();
     if (calib_data)
     {
         for (i = 0; i < 8; i++)
         {
-            if (calib_data->calib_pmu.vaon[i] > target)
+            if (calib_data->calib_pmu.vaon[i] > 1010)
             {
                 vcc_index =  i+calib_data->calib_pmu.vaon_index;
-                *(uint32_t*)(AON1_CTRL_BASE+0x30) |=(((vcc_index&0x3)|((~vcc_index)&0xc))&0xf)<<28;
+                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x30);
+                reg_data &= ~(0xf<<28);
+                reg_data |=(((vcc_index&0x3)|((~vcc_index)&0xc))&0xf)<<28;
+                *(uint32_t*)(AON1_CTRL_BASE+0x30) = reg_data;
+                
+                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x38);
+                reg_data &= ~(0xf<<15);
+                reg_data |= (((vcc_index&0x3)|((~vcc_index)&0xc))&0xf)<<15;
+                *(uint32_t*)(AON1_CTRL_BASE+0x38) = reg_data;
+                break;
             }
         }
         for (i = 0; i < 16; i++)
         {
-            if (calib_data->calib_pmu.vcore[i] > target)
+            if (calib_data->calib_pmu.vcore[i] > 1170)
             {
                 vcc_index =  i+calib_data->calib_pmu.vcore_index;
-                *(uint32_t*)(AON1_CTRL_BASE+0x30) |=(((vcc_index&0xf)|((~vcc_index)&0x10))&0x1f)<<5;
+                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x30);
+                reg_data &= ~(0x1f<<5);
+                reg_data |=(((vcc_index&0xf)|((~vcc_index)&0x10))&0x1f)<<5;
+                *(uint32_t*)(AON1_CTRL_BASE+0x30) = reg_data;
+                break;
             }
         }
-        for (i = 0; i < 16; i++)
+        for (i = 15; i >= 0; i--)
         {
-            if (calib_data->calib_pmu.vdc33[i] > target)
+            if (calib_data->calib_pmu.vdc33[i] > 1470)
             {
                 vcc_index =  i+calib_data->calib_pmu.vdc33_index;
-                *(uint32_t*)(AON1_CTRL_BASE+0x34) |=(vcc_index&0x3f)<<14;
+                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x34);
+                reg_data &= ~(0x3f<<14);
+                reg_data |=(vcc_index&0x3f)<<14;
+                *(uint32_t*)(AON1_CTRL_BASE+0x34) = reg_data;
+                break;
             }
         }
+        return 0;
     }
-
     return -1;
 }
 
 #endif
 
-#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916) || (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916) 
 
+static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selection)
+{
+    FLASH_PRE_OPS();
+    {
+        uint16_t status = ROM_FlashGetStatusReg();
+        *reverse_selection = ((status >> 14) & 1ul);
+        *region = (0x1ful & (status >> 2));
+    }
+    FLASH_POST_OPS();
+}
+
+void flash_enable_write_protection(flash_region_t region, uint8_t reverse_selection)
+{
+    FLASH_PRE_OPS();
+    {
+        uint16_t status = ROM_FlashGetStatusReg();
+        uint16_t old_status = status;
+        status &= ~((1ul << 14) | (0x1ful << 2));
+        status |= (uint16_t)reverse_selection << 14 | ((uint16_t)region << 2);
+        if (old_status != status)
+           ROM_FlashSetStatusReg(status);
+    }
+    FLASH_POST_OPS();
+}
+
+#elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
 static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selection)
 {

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -1,7 +1,12 @@
 #include <stdint.h>
+#include <stddef.h>
 #include <string.h>
 
 #include "eflash.h"
+
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916) || (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selection);
+#endif
 
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
 
@@ -576,31 +581,6 @@ const void *flash_get_adc_calib_data(void)
         return NULL;
 }
 
-static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selection)
-{
-    FLASH_PRE_OPS();
-    {
-        uint16_t status = ROM_FlashGetStatusReg();
-        *reverse_selection = ((status >> 14) & 1ul);
-        *region = (0x1ful & (status >> 2));
-    }
-    FLASH_POST_OPS();
-}
-
-void flash_enable_write_protection(flash_region_t region, uint8_t reverse_selection)
-{
-    FLASH_PRE_OPS();
-    {
-        uint16_t status = ROM_FlashGetStatusReg();
-        uint16_t old_status = status;
-        status &= ~((1ul << 14) | (0x1ful << 2));
-        status |= (uint16_t)reverse_selection << 14 | ((uint16_t)region << 2);
-        if (old_status != status)
-           ROM_FlashSetStatusReg(status);
-    }
-    FLASH_POST_OPS();
-}
-
 typedef void (* rom_FlashRUID)(uint32_t *UID);
 #define ROM_FlashRUID  ((rom_FlashRUID) (0x00000a41))
 
@@ -626,8 +606,9 @@ typedef int (* f_flash_do_update)(const int block_num, const fota_update_block_t
 typedef void (*rom_void_void)(void);
 typedef void (*rom_FlashSectorErase)(uint8_t info, uint32_t addr);
 typedef void (*rom_FlashPageProgram)(uint8_t info, uint32_t addr, const uint8_t *data, uint32_t len);
-typedef void (*rom_FlashSetStatusReg)(uint16_t data);
-typedef uint16_t (*rom_FlashGetStatusReg)(void);
+typedef void (*rom_FlashWriteStatusReg)(uint16_t data);
+typedef uint8_t (*rom_FlashReadReg)(uint8_t cmd);
+typedef uint32_t (*rom_FlashSecurityPageRead)(uint32_t addr);
 
 #define ROM_erase_flash_sector              ((f_erase_flash_sector)0x00008977)
 #define ROM_program_flash                   ((f_program_flash)0x00025de5)
@@ -640,6 +621,10 @@ typedef uint16_t (*rom_FlashGetStatusReg)(void);
 #define ROM_FlashPageProgram                ((rom_FlashPageProgram)0x000007c9)
 
 #define IS_CONTINUOUS_MODE()                ((io_read(0x40150004) & 0x1000000ul) != 0)
+
+#define ROM_FlashReadReg                    ((rom_FlashReadReg)(0x000009dd))
+#define ROM_FlashWriteStatusReg             ((rom_FlashWriteStatusReg)(0x00000b71))
+#define read_flash_security                 ((rom_FlashSecurityPageRead)(0x00000a4d))
 
 #define FLASH_PRE_OPS()                         \
     uint32_t prim = __get_PRIMASK();            \
@@ -748,4 +733,362 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
     return r;
 }
 
+uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
+    uint16_t crc = 0xFFFF;
+    while (usDataLen--) {
+        crc ^= *puchMsg++;
+        for (int i = 0; i < 8; i++) {
+            if (crc & 0x0001) {
+                crc = (crc >> 1) ^ 0xA001;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    return ((crc & 0xFF) << 8) | (crc >> 8);
+}
+
+#define FACTORY_DATA_LOC    (0x02000000 + 0x1000)
+#define FACTORY_DIE_INFO_SRC_ADDR      (0x00000000u)
+#define FACTORY_CALIB_SRC_ADDR         (0x00000100u)
+#define FACTORY_DATA_DIE_INFO          (FACTORY_DATA_LOC)
+#define FACTORY_DATA_CALIB             (FACTORY_DATA_LOC + 0x100)
+#define FACTORY_DATA_CLC               (FACTORY_DATA_LOC + 0x200)
+#define ADC_CAL_CHANNEL_NUM            9
+#define ADC_PHY_INT_POINT0             0.3f
+#define ADC_PHY_INT_POINT1             1.0f
+#define ADC_PHY_VBAT_POINT0            0.5f
+#define ADC_PHY_VBAT_POINT1            2.7f
+#define ADC_PHY_VBAT_33                3.3f
+#define ADC_PHY_VBAT_25                2.5f
+
+
+static uint16_t calc_factory_info_crc16(const die_info_t *info)
+{
+    return crc16((uint8_t *)info, sizeof(die_info_t) - 4);
+}
+
+static uint16_t calc_factory_calib_crc16(const factory_calib_data_t *calib)
+{
+    return crc16((uint8_t *)calib, sizeof(factory_calib_data_t));
+}
+
+static void copy_security_bytes(uint8_t *dst, uint32_t src, uint32_t size)
+{
+    while (size >= 4U)
+    {
+        uint32_t word = read_flash_security(src);
+        memcpy(dst, &word, sizeof(word));
+        dst += sizeof(word);
+        src += sizeof(word);
+        size -= sizeof(word);
+    }
+
+    if (size > 0U)
+    {
+        uint32_t word = read_flash_security(src);
+        memcpy(dst, &word, size);
+    }
+}
+
+static int factory_data_ready(void)
+{
+    const factory_clc_data_t *factory = (const factory_clc_data_t *)FACTORY_DATA_CLC;
+
+    if ((factory->magic_0 != FACTORY_DATA_MAGIC_0) ||
+        (factory->magic_1 != FACTORY_DATA_MAGIC_1))
+        return 0;
+
+    return 1;
+}
+
+static int factory_clc_data_ready(const factory_clc_data_t *data)
+{
+    if (data == NULL)
+        return 0;
+
+    if ((data->magic_0 != FACTORY_DATA_MAGIC_0) ||
+        (data->magic_1 != FACTORY_DATA_MAGIC_1))
+        return 0;
+
+    return data->version == FACTORY_CLC_DATA_VERSION;
+}
+
+static void factory_set_linear_calib(adc_linear_calib_t *cal,
+                                     uint16_t raw0,
+                                     float phy0,
+                                     uint16_t raw1,
+                                     float phy1)
+{
+    if ((cal == NULL) || (raw0 == raw1))
+        return;
+
+    cal->k = (phy1 - phy0) / (float)((int32_t)raw1 - (int32_t)raw0);
+    cal->b = phy0 - cal->k * (float)raw0;
+}
+
+static void factory_set_vbat_calib(adc_vbat_calib_t *cal,
+                                   uint16_t raw_vbat33,
+                                   float vbat33,
+                                   uint16_t raw_vbat25,
+                                   float vbat25)
+{
+    const float x0 = (raw_vbat33 == 0U) ? 0.0f : (1.0f / (float)raw_vbat33);
+    const float x1 = (raw_vbat25 == 0U) ? 0.0f : (1.0f / (float)raw_vbat25);
+
+    if ((cal == NULL) || (x0 == x1))
+        return;
+
+    cal->k = (vbat25 - vbat33) / (x1 - x0);
+    cal->b = vbat33 - cal->k * x0;
+}
+
+void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_data_t *dst)
+{
+    int i;
+
+    if ((src == NULL) || (dst == NULL))
+        return;
+
+    memset(dst, 0xff, sizeof(*dst));
+    dst->magic_0 = FACTORY_DATA_MAGIC_0;
+    dst->magic_1 = FACTORY_DATA_MAGIC_1;
+    dst->version = FACTORY_CLC_DATA_VERSION;
+    dst->flags = 0;
+
+    for (i = 0; i < ADC_CAL_CHANNEL_NUM; ++i)
+    {
+        factory_set_linear_calib(&dst->ch0_8_int_ref[i],
+                                 src->calib_adc.int_vbat33_ain0v3_ch0_8[i],
+                                 ADC_PHY_INT_POINT0,
+                                 src->calib_adc.int_vbat33_ain1v0_ch0_8[i],
+                                 ADC_PHY_INT_POINT1);
+        factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
+                                 src->calib_adc.vbat33_flt_ain0v5_ch0_8[i],
+                                 ADC_PHY_VBAT_POINT0,
+                                 src->calib_adc.vbat33_flt_ain2v7_ch0_8[i],
+                                 ADC_PHY_VBAT_POINT1);
+    }
+
+    factory_set_vbat_calib(&dst->ch9_vbat,
+                           src->calib_adc.vbat33_flt_int_ch9_11[0],
+                           ADC_PHY_VBAT_33,
+                           src->calib_adc.vbat25_flt_int_ch9_11[0],
+                           ADC_PHY_VBAT_25);
+}
+
+int flash_prepare_factory_data(void)
+{
+    factory_calib_data_t calib;
+    die_info_t die_info;
+    uint8_t region;
+    uint8_t reverse_selection;
+
+    if (factory_data_ready())
+        return 0;
+    
+    flash_read_protection_status(&region, &reverse_selection);
+    flash_enable_write_protection(FLASH_REGION_NONE, 0);
+    
+    ROM_FlashSectorErase(0x20, FACTORY_DATA_LOC);
+
+    copy_security_bytes((uint8_t *)&die_info,
+                        FACTORY_DIE_INFO_SRC_ADDR,
+                        sizeof(die_info));
+    copy_security_bytes((uint8_t *)&calib,
+                        FACTORY_CALIB_SRC_ADDR,
+                        sizeof(calib));
+
+    uint16_t crc = calc_factory_info_crc16(&die_info);
+    if (crc != die_info.info_crc16)
+        return 1;
+    crc = calc_factory_calib_crc16(&calib);
+    if (crc != die_info.trim_crc16)
+        return 2;
+
+    if (write_flash(FACTORY_DATA_LOC,
+                    (const uint8_t *)&die_info,
+                    sizeof(die_info)) != 0)
+        goto check_failed;
+    if (write_flash(FACTORY_DATA_CALIB,
+                    (const uint8_t *)&calib,
+                    sizeof(calib)) != 0)
+        goto check_failed;
+
+    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_DIE_INFO),
+               (const void *)&die_info,
+               sizeof(die_info)) != 0)
+        goto check_failed;
+    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_CALIB),
+               (const void *)&calib,
+               sizeof(calib)) != 0)
+        goto check_failed;
+
+    {
+        uint32_t magic[2];
+
+        magic[0] = FACTORY_DATA_MAGIC_0;
+        magic[1] = FACTORY_DATA_MAGIC_1;
+        if (write_flash(FACTORY_DATA_CLC,
+                        (const uint8_t *)magic,
+                        sizeof(magic)) != 0)
+            goto check_failed;
+    }
+
+    flash_enable_write_protection(region, reverse_selection);
+    return 0;
+
+check_failed:
+    erase_flash_sector(FACTORY_DATA_LOC);
+    flash_enable_write_protection(region, reverse_selection);
+    return 3;
+}
+
+const die_info_t *flash_get_die_info(void)
+{
+    if (flash_prepare_factory_data() == 0)
+        return (const die_info_t *)FACTORY_DATA_DIE_INFO;
+
+    return NULL;
+}
+
+const factory_calib_data_t *flash_get_factory_calib_data(void)
+{
+    if (flash_prepare_factory_data() == 0)
+        return (const factory_calib_data_t *)FACTORY_DATA_CALIB;
+
+    return NULL;
+}
+
+const factory_clc_data_t *flash_get_factory_clc_data(void)
+{
+    const factory_clc_data_t *data;
+    const factory_calib_data_t *calib;
+    factory_clc_data_t generated;
+
+    if (flash_prepare_factory_data() != 0)
+        return NULL;
+
+    data = (const factory_clc_data_t *)FACTORY_DATA_CLC;
+    if (factory_clc_data_ready(data))
+        return data;
+
+    calib = flash_get_factory_calib_data();
+    if (calib == NULL)
+        return NULL;
+
+    flash_build_factory_clc_data(calib, &generated);
+    if (flash_store_factory_clc_data(&generated) != 0)
+        return NULL;
+
+    data = (const factory_clc_data_t *)FACTORY_DATA_CLC;
+    return factory_clc_data_ready(data) ? data : NULL;
+}
+
+int flash_store_factory_clc_data(const factory_clc_data_t *data)
+{
+    uint8_t region;
+    uint8_t reverse_selection;
+
+    if (data == NULL)
+        return 1;
+
+    flash_read_protection_status(&region, &reverse_selection);
+    flash_enable_write_protection(FLASH_REGION_NONE, 0);
+
+    erase_flash_page(FACTORY_DATA_CLC);
+    if (write_flash(FACTORY_DATA_CLC,
+                    (const uint8_t *)data,
+                    sizeof(*data)) != 0)
+        goto store_failed;
+    if (memcmp((const void *)FACTORY_DATA_CLC,
+               (const void *)data,
+               sizeof(*data)) != 0)
+        goto store_failed;
+
+    flash_enable_write_protection(region, reverse_selection);
+    return 0;
+
+store_failed:
+    flash_enable_write_protection(region, reverse_selection);
+    return 2;
+}
+
+typedef void (* rom_FlashRUID)(uint32_t *UID);
+#define ROM_FlashRUID  ((rom_FlashRUID) (0x00000989))
+
+void flash_read_uid(uint32_t uid[4])
+{
+    FLASH_PRE_OPS();
+    {
+        ROM_FlashRUID(uid);
+    }
+    FLASH_POST_OPS();
+}
+
+int get_vaon(int target)
+{
+    uint8_t i;
+    uint8_t vcc_index;
+    const factory_calib_data_t * calib_data = flash_get_factory_calib_data();
+    if (calib_data)
+    {
+        for (i = 0; i < 8; i++)
+        {
+            if (calib_data->calib_pmu.vaon[i] > target)
+            {
+                vcc_index =  i+calib_data->calib_pmu.vaon_index;
+                *(uint32_t*)(AON1_CTRL_BASE+0x30) |=(((vcc_index&0x3)|((~vcc_index)&0xc))&0xf)<<28;
+            }
+        }
+        for (i = 0; i < 16; i++)
+        {
+            if (calib_data->calib_pmu.vcore[i] > target)
+            {
+                vcc_index =  i+calib_data->calib_pmu.vcore_index;
+                *(uint32_t*)(AON1_CTRL_BASE+0x30) |=(((vcc_index&0xf)|((~vcc_index)&0x10))&0x1f)<<5;
+            }
+        }
+        for (i = 0; i < 16; i++)
+        {
+            if (calib_data->calib_pmu.vdc33[i] > target)
+            {
+                vcc_index =  i+calib_data->calib_pmu.vdc33_index;
+                *(uint32_t*)(AON1_CTRL_BASE+0x34) |=(vcc_index&0x3f)<<14;
+            }
+        }
+    }
+
+    return -1;
+}
+
+#endif
+
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916) || (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+
+
+static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selection)
+{
+    FLASH_PRE_OPS();
+    {
+        uint16_t status = ROM_FlashReadReg(0x05) | (ROM_FlashReadReg(0x35)<<8);
+        *reverse_selection = ((status >> 14) & 1ul);
+        *region = (0x1ful & (status >> 2));
+    }
+    FLASH_POST_OPS();
+}
+
+void flash_enable_write_protection(flash_region_t region, uint8_t reverse_selection)
+{
+    FLASH_PRE_OPS();
+    {
+        uint8_t status = ROM_FlashReadReg(0x05) | (ROM_FlashReadReg(0x35)<<8);
+        uint16_t old_status = status;
+        status &= ~((1ul << 14) | (0x1ful << 2));
+        status |= (uint16_t)reverse_selection << 14 | ((uint16_t)region << 2);
+        if (old_status != status)
+            ROM_FlashWriteStatusReg(status);
+    }
+    FLASH_POST_OPS();
+}
 #endif

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -740,7 +740,7 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
         ROM_FlashEnableContinuousMode();
     }
     
-    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1<<31);
+    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1ul<<31);
     
     int r = ROM_flash_do_update(block_num, blocks, page_buffer);
     SYSCTRL_ICacheFlush();
@@ -753,9 +753,10 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
 
 static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
     uint16_t crc = 0xFFFF;
+	  int i;
     while (usDataLen--) {
         crc ^= *puchMsg++;
-        for (int i = 0; i < 8; i++) {
+        for (i = 0; i < 8; i++) {
             if (crc & 0x0001) {
                 crc = (crc >> 1) ^ 0xA001;
             } else {
@@ -916,7 +917,7 @@ int flash_prepare_factory_data(void)
     if (factory_data_ready())
         return 0;
 
-    reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18))&(0x1<<31);
+    reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18))&(0x1ul<<31);
     
     flash_read_protection_status(&region, &reverse_selection);
     flash_enable_write_protection(FLASH_REGION_NONE, 0);
@@ -957,12 +958,12 @@ int flash_prepare_factory_data(void)
 
     flash_build_factory_clc_data(&calib, &generated);
 
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1<<31);
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1ul<<31);
     if (write_flash(FACTORY_DATA_CLC,
                     (const uint8_t *)&generated,
                     sizeof(generated) - 8) != 0)
         goto check_failed;
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1<<31);
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1ul<<31);
     if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_CLC),
                (const void *)&generated,
                sizeof(generated) - 8) != 0)
@@ -972,13 +973,13 @@ int flash_prepare_factory_data(void)
                     8) != 0)
         goto check_failed;
 
-    flash_enable_write_protection(region, reverse_selection);
+    flash_enable_write_protection((flash_region_t)region, reverse_selection);
     return 0;
 
 check_failed:
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1<<31);
+    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1ul<<31);
     erase_flash_sector(FACTORY_DATA_LOC);
-    flash_enable_write_protection(region, reverse_selection);
+    flash_enable_write_protection((flash_region_t)region, reverse_selection);
     
     return 3;
 }
@@ -1025,7 +1026,7 @@ int Vcore_calib(void)
             {
                 vcc_index =  i+calib_data->calib_pmu.vaon_index;
                 reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x30);
-                reg_data &= ~(0xf<<28);
+                reg_data &= ~(0xful<<28);
                 reg_data |=(((vcc_index&0x3)|((~vcc_index)&0xc))&0xf)<<28;
                 *(uint32_t*)(AON1_CTRL_BASE+0x30) = reg_data;
                 

--- a/src/BSP/eflash.h
+++ b/src/BSP/eflash.h
@@ -388,6 +388,229 @@ int erase_flash_sector(const uint32_t addr);
  */
 int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint8_t *ram_buffer);
 
+
+typedef enum
+{
+    FLASH_REGION_NONE       = 0x00,         // none         (        0KB)
+    FLASH_REGION_UPPER_1_8  = 0x01,         // upper 1/8    (upper  64KB)
+    FLASH_REGION_UPPER_1_4  = 0x02,         // upper 1/4    (upper 128KB)
+    FLASH_REGION_UPPER_1_2  = 0x03,         // upper 1/2    (upper 256KB)
+    FLASH_REGION_LOWER_1_8  = 0x09,         // lower 1/8    (lower  64KB)
+    FLASH_REGION_LOWER_1_4  = 0x0A,         // lower 1/4    (lower 128KB)
+    FLASH_REGION_LOWER_1_2  = 0x0B,         // lower 1/2    (lower 256KB)
+    FLASH_REGION_UPPER_1_128 = 0x11,        // upper 1/128  (upper   4KB)
+    FLASH_REGION_UPPER_1_64  = 0x12,        // upper 1/64   (upper   8KB)
+    FLASH_REGION_UPPER_1_32  = 0x13,        // upper 1/32   (upper  16KB)
+    FLASH_REGION_UPPER_1_16  = 0x14,        // upper 1/16   (upper  32KB)
+    FLASH_REGION_LOWER_1_128 = 0x19,        // lower 1/128  (lower   4KB)
+    FLASH_REGION_LOWER_1_64  = 0x1A,        // lower 1/64   (lower   8KB)
+    FLASH_REGION_LOWER_1_32  = 0x1B,        // lower 1/32   (lower  16KB)
+    FLASH_REGION_LOWER_1_16  = 0x1C,        // lower 1/16   (lower  32KB)
+    FLASH_REGION_ALL         = 0x1f,        // all          (      512KB)
+} flash_region_t;
+
+/**
+ * @brief Enable write protection on a selected region
+ *
+ * e.g.
+ *
+ * ```c
+ * // turn on write protection for the upper 1/8 of flash
+ * flash_enable_write_protection(FLASH_REGION_UPPER_1_8, 0);
+ *
+ * // turn on write protection for the lower 7/8 of flash,
+ * // i.e. reverse the selection of `FLASH_REGION_UPPER_1_8`
+ * flash_enable_write_protection(FLASH_REGION_UPPER_1_8, 1);
+ * ```
+ *
+ * Call this before doing write operations on flash if related region is write
+ * protected. Select NONE region will disable the protection completely:
+ *
+ * ```c
+ * flash_enable_write_protection(FLASH_REGION_NONE, 0);
+ * ```
+ *
+ * Note: Write protection is a global configuration for the flash. It is impossible
+ * to enable the protection for two separated region, such as `FLASH_REGION_UPPER_1_8`,
+ * `FLASH_REGION_LOWER_1_128` by invoking this API twice.
+ *
+ * @param[in] region                specify a region
+ * @param[in] reverse_selection     select `region` (0) or reverse the selection of `region` (1)
+ */
+void flash_enable_write_protection(flash_region_t region, uint8_t reverse_selection);
+
+
+#pragma pack (push, 1)
+typedef struct
+{
+    uint16_t version;
+    uint8_t metal_id;
+    uint8_t bin_number;
+    uint8_t chip_uuid[16];
+    uint16_t ate_version;
+    uint16_t dut_version;
+    uint8_t batch_number[16];
+    uint16_t info_crc16;
+    uint16_t trim_crc16;
+} die_info_t;
+
+typedef struct
+{
+    uint8_t version;
+    uint8_t v33_index;
+    uint8_t v33[16];
+    uint8_t vaon_index;
+    uint8_t vaon[16];
+    uint8_t vdc33_index;
+    uint8_t vdc33[32];
+    uint8_t vcore_index;
+    uint8_t vcore[32];
+}factory_calib_pmu_t;
+
+typedef struct {
+    uint8_t version;
+    uint16_t channel_mask;
+    uint16_t int_vbat33_ain0v3_ch0_8[9];
+    uint16_t int_vbat33_ain1v0_ch0_8[9];
+    uint16_t vbat33_flt_ain0v5_ch0_8[9];
+    uint16_t vbat33_flt_ain2v7_ch0_8[9];
+    uint16_t int_vbat33_int_ch9_11[3];
+    uint16_t vbat33_flt_int_ch9_11[3];
+    uint16_t vbat25_flt_int_ch9_11[3];
+} factory_calib_adc_t;
+
+typedef struct {
+    uint8_t version;
+    uint16_t verf;
+    uint16_t mic_bias_int;
+    uint16_t vp_2v0_vn0v0_int;
+    uint16_t vp_0v0_vn2v0_int;
+    uint16_t vp_1v5_int;
+    uint16_t vp_0v5_int;
+    uint16_t mic_bias_ext;
+    uint16_t vp_2v0_vn0v0_ext;
+    uint16_t vp_0v0_vn2v0_ext;
+    uint16_t vp_1v5_ext;
+    uint16_t vp_0v5_ext;
+} factory_calib_asdm_t;
+
+typedef struct
+{
+    factory_calib_pmu_t calib_pmu;
+    factory_calib_adc_t calib_adc;
+    factory_calib_asdm_t calib_asdm;
+} factory_calib_data_t;
+
+#define FACTORY_DATA_MAGIC_0    0x494E4743u
+#define FACTORY_DATA_MAGIC_1    0x48495053u
+
+typedef struct
+{
+    float k;
+    float b;
+} adc_linear_calib_t;
+
+typedef struct
+{
+    float k;
+    float b;
+} adc_vbat_calib_t;
+
+typedef struct
+{
+    uint32_t magic_0;
+    uint32_t magic_1;
+    uint16_t version;
+    uint16_t flags;
+    adc_linear_calib_t ch0_8_int_ref[9];
+    adc_linear_calib_t ch0_8_vbat_ref[9];
+    adc_vbat_calib_t ch9_vbat;
+    uint32_t reserved[10];
+} factory_clc_data_t;
+#pragma pack (pop)
+
+#define FACTORY_CLC_DATA_VERSION       0x0001u
+
+/**
+ * @brief Prepare factory data in flash
+ *
+ * This function copies factory data from security pages to normal
+ * pages in flash when needed.
+ *
+ * @return                      0 if succeeded else non-0
+ */
+int flash_prepare_factory_data(void);
+
+/**
+ * @brief Get die information from flash
+ *
+ * When such information does not exists, NULL is returned.
+ *
+ * This function uses `flash_prepare_factory_data()`.
+ *
+ * @return                      die information
+ */
+const die_info_t *flash_get_die_info(void);
+
+/**
+ * @brief Get factory calibration data from flash
+ *
+ * When such information does not exists, NULL is returned.
+ *
+ * This function uses `flash_prepare_factory_data()`.
+ *
+ * @return                      factory data
+ */
+const factory_calib_data_t *flash_get_factory_calib_data(void);
+
+/**
+ * @brief Get calculated calibration data from flash
+ *
+ * This function uses `flash_prepare_factory_data()`.
+ *
+ * @return                      cached calibration data
+ */
+const factory_clc_data_t *flash_get_factory_clc_data(void);
+
+/**
+ * @brief Store calculated calibration data to flash
+ *
+ * @param[in] data              calibration data to be stored
+ * @return                      0 if succeeded else non-0
+ */
+int flash_store_factory_clc_data(const factory_clc_data_t *data);
+
+/**
+ * @brief Build calculated ADC calibration data from factory FT data
+ *
+ * @param[in] src               source FT data
+ * @param[out] dst              calculated calibration data
+ */
+void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_data_t *dst);
+
+/**
+ * @brief Get ADC calibration data from flash
+ *
+ * Note: There are multiple versions of ADC calibration data,
+ *       so, here, a plain pointer is returned.
+ *
+ * This function uses `flash_prepare_factory_data()`.
+ *
+ * See `adc_calib_ver` in `factory_calib_data_t`.
+ *
+ * When such information does not exists, NULL is returned.
+ *
+ * @return                      ADC calibration data
+ */
+const void *flash_get_adc_calib_data(void);
+
+/**
+ * @brief Read UID of flash
+ *
+ * @param[out]  uid            128-bit UID
+ */
+void flash_read_uid(uint32_t uid[4]);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/BSP/eflash.h
+++ b/src/BSP/eflash.h
@@ -9,10 +9,35 @@
 extern "C" {
 #endif
 
+#if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+/**
+ * @note
+ * For the ING20, when FLASH_PROGRAM_WITH_DMA is set to 0, it is recommended that the size of a single write
+ * operation not exceed 32 bytes. Any data exceeding 32 bytes will be split into multiple write operations,
+ * increasing the number of flash write operations.
+ *
+ * When FLASH_PROGRAM_WITH_DMA is set to 1, the interface will use DMA Channel 0 to operate the flash.
+ * Note that DMA Channel 0 must not be used for other applications;
+ * otherwise, the interface will modify the configuration of Channel 0, causing DMA transfer errors. Additionally,
+ * when using DMA transfers, the interface will set the flash frequency to 24 MHz. At higher FLASH frequencies,
+ * programming more than 32 bytes of data may result in an error, manifesting as only 16 bytes being successfully programmed.
+ */
+#ifndef FLASH_PROGRAM_WITH_DMA
+#define FLASH_PROGRAM_WITH_DMA      0
+#endif
+
+#endif
+
 /**
  * @brief Erase a block of data in flash then write data.
  *
- * Note: For ING916, `buffer` must not be in Flash.
+ * Note: For ING916 or ING20, `buffer` must not be in Flash.
+ *
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * For ING20.
+ * Please refer to the description of the FLASH_PROGRAM_WITH_DMA macro.
+ * It is recommended that a single write operation not exceed 32 bytes.
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  *
  * @param[in] dest_addr         target address (unified address, aligned at EFLASH_ERASABLE_SIZE) in flash
  * @param[in] buffer            buffer to be written
@@ -27,13 +52,19 @@ int program_flash(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size
  * Note: `dest_addr` must points to a block of flash that has been erased, otherwise,
  *        data can't be written into it.
  *
- * For ING916:
+ * For ING916 ING20:
  *      * `buffer` must be in RAM. In order to copy data within flash, it must be copied to RAM
  *          firstly, then write this piece of RAM to flash.
  *
  * For ING918:
  *      * `dest_addr` must be 32-bit aligned
  *      * `size` must be multiple of 4 bytes.
+ *
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * For ING20.
+ * Please refer to the description of the FLASH_PROGRAM_WITH_DMA macro.
+ * It is recommended that a single write operation not exceed 32 bytes.
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  *
  * @param[in] dest_addr         target address (unified address) in flash
  * @param[in] buffer            buffer to be written
@@ -458,22 +489,20 @@ typedef struct
 {
     uint8_t version;
     uint8_t v33_index;
-    uint8_t v33[16];
+    uint16_t v33[8];
     uint8_t vaon_index;
-    uint8_t vaon[16];
+    uint16_t vaon[8];
     uint8_t vdc33_index;
-    uint8_t vdc33[32];
+    uint16_t vdc33[16];
     uint8_t vcore_index;
-    uint8_t vcore[32];
+    uint16_t vcore[16];
 }factory_calib_pmu_t;
 
 typedef struct {
     uint8_t version;
     uint16_t channel_mask;
-    uint16_t int_vbat33_ain0v3_ch0_8[9];
-    uint16_t int_vbat33_ain1v0_ch0_8[9];
-    uint16_t vbat33_flt_ain0v5_ch0_8[9];
-    uint16_t vbat33_flt_ain2v7_ch0_8[9];
+    uint16_t int_vbat33_ain_ch0_8[9][2];
+    uint16_t vbat33_flt_ain_ch0_8[9][2];
     uint16_t int_vbat33_int_ch9_11[3];
     uint16_t vbat33_flt_int_ch9_11[3];
     uint16_t vbat25_flt_int_ch9_11[3];
@@ -518,14 +547,14 @@ typedef struct
 
 typedef struct
 {
-    uint32_t magic_0;
-    uint32_t magic_1;
     uint16_t version;
     uint16_t flags;
     adc_linear_calib_t ch0_8_int_ref[9];
     adc_linear_calib_t ch0_8_vbat_ref[9];
     adc_vbat_calib_t ch9_vbat;
     uint32_t reserved[10];
+    uint32_t magic_0;
+    uint32_t magic_1;
 } factory_clc_data_t;
 #pragma pack (pop)
 
@@ -573,14 +602,6 @@ const factory_calib_data_t *flash_get_factory_calib_data(void);
 const factory_clc_data_t *flash_get_factory_clc_data(void);
 
 /**
- * @brief Store calculated calibration data to flash
- *
- * @param[in] data              calibration data to be stored
- * @return                      0 if succeeded else non-0
- */
-int flash_store_factory_clc_data(const factory_clc_data_t *data);
-
-/**
  * @brief Build calculated ADC calibration data from factory FT data
  *
  * @param[in] src               source FT data
@@ -589,20 +610,10 @@ int flash_store_factory_clc_data(const factory_clc_data_t *data);
 void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_data_t *dst);
 
 /**
- * @brief Get ADC calibration data from flash
+ * @brief Set Vcore value from FT data;
  *
- * Note: There are multiple versions of ADC calibration data,
- *       so, here, a plain pointer is returned.
- *
- * This function uses `flash_prepare_factory_data()`.
- *
- * See `adc_calib_ver` in `factory_calib_data_t`.
- *
- * When such information does not exists, NULL is returned.
- *
- * @return                      ADC calibration data
  */
-const void *flash_get_adc_calib_data(void);
+int Vcore_calib(void);
 
 /**
  * @brief Read UID of flash

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -756,7 +756,6 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
     ADC_EnableCtrlSignal();
 }
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
-//#include "platform_api.h"
 #include <stdlib.h>
 #include <string.h>
 #include "eflash.h"
@@ -909,9 +908,6 @@ uint16_t ADC_ReadChannelData(const uint8_t channel_id)
 
 void ADC_HardwareCalibration(void)
 {
-    volatile uint32_t rwData;
-    int i;
-    uint32_t j;
     ADC_RegWr(SADC_CFG_0, 1, 17);
     ADC_RegWrBits(SADC_CFG_0, 1, 18, 4);
     ADC_RegClr(SADC_CFG_0, 9, 1);
@@ -920,33 +916,15 @@ void ADC_HardwareCalibration(void)
     ADC_RegWrBits(SADC_CFG_2, 1, 3, 12);
     ADC_RegWr(SADC_INT_MAKS, 1, 0);
     ADC_RegWr(SADC_CFG_0, 1, 1);
-    for (i = 1; i < 8; i++)
-    {
-        ADC_RegWrBits(SADC_CFG_3, i, 16, 3);
-        for (j = 0; j < 100; j++) __NOP();
-        rwData = APB_SADC->sadc_cfg3;
-    }
     ADC_RegWr(SADC_CFG_2, 1, 2);
     while (APB_SADC->sadc_int & 0x1);
-    rwData = APB_SADC->sadc_data;
-    ADC_RegClr(SADC_CFG_0, 1, 1);
-    ADC_RegClr(SADC_CFG_2, 2, 1);
-    ADC_RegWr(SADC_STATUS, 1, 22);
-
-    ADC_RegClr(SADC_CFG_0, 0, 1);
-    ADC_RegWr(SADC_CFG_0, 1, 1);
-    for (i = 1; i < 8; i++)
-    {
-        ADC_RegWrBits(SADC_CFG_3, i, 16, 3);
-        for (j = 0; j < 100; j++) __NOP();
-        rwData = APB_SADC->sadc_cfg3;
-    }
     ADC_RegClr(SADC_CFG_2, 3, 12);
     ADC_RegClr(SADC_CFG_2, 0, 1);
     while (ADC_GetBusyStatus());
     ADC_RegClr(SADC_CFG_0, 1, 1);
+    ADC_RegClr(SADC_CFG_0, 9, 1);
+    ADC_RegClr(SADC_CFG_2, 2, 1);
     APB_SADC->sadc_int_mask = 0;
-    (void)rwData;
 }
 
 void ADC_Reset(void)
@@ -964,6 +942,7 @@ void ADC_Reset(void)
     ADC_RegClr(SADC_CFG_2, 0, 1);
     while (ADC_GetBusyStatus());
     ADC_RegClr(SADC_CFG_0, 1, 1);
+    ADC_RegClr(SADC_CFG_2, 2, 1);
     APB_SADC->sadc_int_mask = 0;
 }
 
@@ -984,12 +963,18 @@ void ADC_SetVref(SADC_Vref vref)
     switch (vref)
     {
         case VREF_IN_MODE:
+            ADC_RegClr(SADC_CFG_0, 29, 1);
+            ADC_RegClr(SADC_CFG_0, 7, 1);
             ADC_RegWr(SADC_CFG_0, 1, 3);
         break;
         case VREF_OUT_MODE:
+            ADC_RegClr(SADC_CFG_0, 3, 1);
+            ADC_RegClr(SADC_CFG_0, 7, 1);
             ADC_RegWr(SADC_CFG_0, 1, 29);
         break;
         case VREF_LDO33_MODE:
+            ADC_RegClr(SADC_CFG_0, 29, 1);
+            ADC_RegClr(SADC_CFG_0, 3, 1);
             ADC_RegWr(SADC_CFG_0, 1, 7);
         break;
         default:
@@ -1009,7 +994,7 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
     if (enNum) {
         ADC_IntEnable(1);
         ADC_SetIntTrig(enNum);
-    } else if (dmaEnNum) { 
+    } else if (dmaEnNum) {
         ADC_DmaEnable(1);
         ADC_SetDmaTrig(dmaEnNum);
     }
@@ -1031,38 +1016,33 @@ static SADC_Vref ADC_GetCurrentVref(void)
 
 static float ADC_ApplyLinearCalib(const adc_linear_calib_t *cal, uint16_t raw)
 {
-    if (cal == NULL)
-        return 0.0f;
+    if (cal == 0)
+        return 1.0f;
 
     return cal->k * (float)raw + cal->b;
 }
 
 static float ADC_ApplyVBatCalib(const adc_vbat_calib_t *cal, uint16_t raw)
 {
-    if ((cal == NULL) || (raw == 0U))
+    if ((cal == 0) || (raw == 0U))
         return 0.0f;
 
-    return cal->k / (float)raw + cal->b;
+    return cal->k *(1.0f / (float)raw)  + cal->b;
 }
 
 static const factory_clc_data_t *ADC_GetCalibrationData(void)
 {
     const factory_clc_data_t *stored = flash_get_factory_clc_data();
 
-    if (stored == NULL)
-        return NULL;
+    if (stored == 0)
+        return 0;
 
     if ((stored->magic_0 != FACTORY_DATA_MAGIC_0) ||
         (stored->magic_1 != FACTORY_DATA_MAGIC_1) ||
         (stored->version != FACTORY_CLC_DATA_VERSION))
-        return NULL;
+        return 0;
 
     return stored;
-}
-
-int ADC_InitCalibration(void)
-{
-    return (ADC_GetCalibrationData() != NULL) ? 0 : 2;
 }
 
 float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw)
@@ -1085,7 +1065,7 @@ float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw)
     if (ch == ADC_CH_9)
     {
         if (ADC_GetCurrentVref() == VREF_IN_MODE)
-            return 1.2f;
+            return 1.8f;
 
         return ADC_ApplyVBatCalib(&cal->ch9_vbat, raw);
     }
@@ -1093,13 +1073,28 @@ float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw)
     return (float)raw;
 }
 
-float ADC_GetVBatVoltage(void)
+float ADC_GetCalibValueVRefVBat(SADC_channelId ch, uint16_t raw, float vbat)
 {
-    return ADC_GetCalibratedValue(ADC_CH_9, ADC_ReadChannelData(ADC_CH_9));
+    const factory_clc_data_t *cal;
+    adc_linear_calib_t linear_data;
+
+    cal = ADC_GetCalibrationData();
+    if (cal == NULL)
+        return (float)raw;
+
+    if (ch <= ADC_CH_8)
+    {
+        memcpy(&linear_data, &cal->ch0_8_vbat_ref[ch], sizeof(adc_linear_calib_t));
+        linear_data.k = linear_data.k*(vbat/3.3f);
+        return ADC_ApplyLinearCalib(&linear_data, raw);
+    }
+
+    return (float)raw;
 }
 
-void ADC_ClcCalibration(void)
+float ADC_GetVBatVoltage(uint16_t raw)
 {
-    (void)ADC_InitCalibration();
+    return ADC_GetCalibratedValue(ADC_CH_9, raw);
 }
+
 #endif

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -759,7 +759,7 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
 //#include "platform_api.h"
 #include <stdlib.h>
 #include <string.h>
-//#include "eflash.h"
+#include "eflash.h"
 #define ADC_LEFT_SHIFT(v, s)            ((v) << (s))
 #define ADC_RIGHT_SHIFT(v, s)           ((v) >> (s))
 #define ADC_MK_MASK(b)                  ((ADC_LEFT_SHIFT(1ULL, b)) - (1))
@@ -897,6 +897,16 @@ uint16_t ADC_GetData(const uint32_t data)
     return (uint16_t)(data & ADC_MK_MASK(12));
 }
 
+uint16_t ADC_ReadChannelData(const uint8_t channel_id)
+{
+    const uint32_t data = ADC_PopFifoData();
+
+    if (ADC_GetDataChannel(data) == (SADC_channelId)channel_id)
+        return ADC_GetData(data);
+
+    return 0;
+}
+
 void ADC_HardwareCalibration(void)
 {
     volatile uint32_t rwData;
@@ -999,10 +1009,97 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
     if (enNum) {
         ADC_IntEnable(1);
         ADC_SetIntTrig(enNum);
-    } else if (dmaEnNum) {
+    } else if (dmaEnNum) { 
         ADC_DmaEnable(1);
         ADC_SetDmaTrig(dmaEnNum);
     }
     ADC_SetLoopDelay(loopDelay);
+}
+static SADC_Vref ADC_GetCurrentVref(void)
+{
+    const uint32_t cfg0 = APB_SADC->sadc_cfg[0];
+
+    if (cfg0 & (1u << 3))
+        return VREF_IN_MODE;
+    if (cfg0 & (1u << 29))
+        return VREF_OUT_MODE;
+    if (cfg0 & (1u << 7))
+        return VREF_LDO33_MODE;
+
+    return VREF_IN_MODE;
+}
+
+static float ADC_ApplyLinearCalib(const adc_linear_calib_t *cal, uint16_t raw)
+{
+    if (cal == NULL)
+        return 0.0f;
+
+    return cal->k * (float)raw + cal->b;
+}
+
+static float ADC_ApplyVBatCalib(const adc_vbat_calib_t *cal, uint16_t raw)
+{
+    if ((cal == NULL) || (raw == 0U))
+        return 0.0f;
+
+    return cal->k / (float)raw + cal->b;
+}
+
+static const factory_clc_data_t *ADC_GetCalibrationData(void)
+{
+    const factory_clc_data_t *stored = flash_get_factory_clc_data();
+
+    if (stored == NULL)
+        return NULL;
+
+    if ((stored->magic_0 != FACTORY_DATA_MAGIC_0) ||
+        (stored->magic_1 != FACTORY_DATA_MAGIC_1) ||
+        (stored->version != FACTORY_CLC_DATA_VERSION))
+        return NULL;
+
+    return stored;
+}
+
+int ADC_InitCalibration(void)
+{
+    return (ADC_GetCalibrationData() != NULL) ? 0 : 2;
+}
+
+float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw)
+{
+    const factory_clc_data_t *cal;
+    const adc_linear_calib_t *linear;
+
+    cal = ADC_GetCalibrationData();
+    if (cal == NULL)
+        return (float)raw;
+
+    if (ch <= ADC_CH_8)
+    {
+        linear = (ADC_GetCurrentVref() == VREF_IN_MODE) ?
+                 &cal->ch0_8_int_ref[ch] :
+                 &cal->ch0_8_vbat_ref[ch];
+        return ADC_ApplyLinearCalib(linear, raw);
+    }
+
+    if (ch == ADC_CH_9)
+    {
+        if (ADC_GetCurrentVref() == VREF_IN_MODE)
+            return 1.2f;
+
+        return ADC_ApplyVBatCalib(&cal->ch9_vbat, raw);
+    }
+
+    return (float)raw;
+}
+
+float ADC_GetVBatVoltage(void)
+{
+    return ADC_GetCalibratedValue(ADC_CH_9, ADC_ReadChannelData(ADC_CH_9));
+}
+
+void ADC_ClcCalibration(void)
+{
+    (void)ADC_InitCalibration();
 }
 #endif

--- a/src/FWlib/peripheral_adc.h
+++ b/src/FWlib/peripheral_adc.h
@@ -724,16 +724,13 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
 void ADC_HardwareCalibration(void);
 
 /**
- * @brief Initialize ADC calibration parameters from flash
- *
- * @return                      0 if cached or freshly calculated data is ready else non-0
- */
-int ADC_InitCalibration(void);
-
-/**
  * @brief Convert raw ADC code to calibrated physical value
  *
- * For CH0-CH8 the return value is input voltage in V.
+ * @note
+ * When using VBAT as the standard VREF, if VBAT is not 3.3 V,
+ * Use 'ADC_GetCalibValueVRefVBat'
+ *
+ * For CH0-CH8 the return value. rand in 0-4096.
  * For CH9 under VBAT reference the return value is VBAT voltage in V.
  * For CH10-CH11 the raw code is returned as float.
  *
@@ -744,11 +741,26 @@ int ADC_InitCalibration(void);
 float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw);
 
 /**
+ * @brief Convert raw ADC code to calibrated physical value,
+ * When using VBAT as the standard VREF, if VBAT is not 3.3 V,
+ * you must use this interface to obtain the calibrated value.
+ *
+ * Only CH0-CH8 the return value. rand in 0-4096.
+ *
+ * @param[in] ch                ADC channel
+ * @param[in] raw               raw ADC code
+ * @param[in] vbat              now Vbat value
+ * @return                      calibrated value
+ */
+float ADC_GetCalibValueVRefVBat(SADC_channelId ch, uint16_t raw, float vbat);
+
+/**
  * @brief Read VBAT voltage using CH9 calibration
  *
+ * @param[in] raw               CH9 raw adc vale
  * @return                      VBAT voltage in V
  */
-float ADC_GetVBatVoltage(void);
+float ADC_GetVBatVoltage(uint16_t raw);
 
 
 #endif

--- a/src/FWlib/peripheral_adc.h
+++ b/src/FWlib/peripheral_adc.h
@@ -137,6 +137,25 @@ typedef enum {
 
 typedef struct
 {
+    float k;
+    float b;
+} ADC_LinearCalib_t;
+
+typedef struct
+{
+    float k;
+    float b;
+} ADC_VBatCalib_t;
+
+typedef struct
+{
+    ADC_LinearCalib_t ch0_8_int_ref[9];
+    ADC_LinearCalib_t ch0_8_vbat_ref[9];
+    ADC_VBatCalib_t ch9_vbat;
+} ADC_CalibrationData_t;
+
+typedef struct
+{
     float vref_P;
     float vref_N;
     float (*cb)(const uint16_t);
@@ -647,6 +666,14 @@ SADC_channelId ADC_GetDataChannel(const uint32_t data);
 uint16_t ADC_GetData(const uint32_t data);
 
 /**
+ * @brief Read ADC data in specified channel
+ *
+ * @param[in] channel_id       channel ID
+ * @return                     calibrated ADC data when channel matches else 0
+ */
+uint16_t ADC_ReadChannelData(const uint8_t channel_id);
+
+/**
  * @brief Get ADC-Channel's enabled status
  * Example:
  * 1.single-mode with CH0/CH4/CH6 are enabled, it returns 0x51.
@@ -695,6 +722,33 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
  * @brief ADC hardware calibration
  * */
 void ADC_HardwareCalibration(void);
+
+/**
+ * @brief Initialize ADC calibration parameters from flash
+ *
+ * @return                      0 if cached or freshly calculated data is ready else non-0
+ */
+int ADC_InitCalibration(void);
+
+/**
+ * @brief Convert raw ADC code to calibrated physical value
+ *
+ * For CH0-CH8 the return value is input voltage in V.
+ * For CH9 under VBAT reference the return value is VBAT voltage in V.
+ * For CH10-CH11 the raw code is returned as float.
+ *
+ * @param[in] ch                ADC channel
+ * @param[in] raw               raw ADC code
+ * @return                      calibrated value
+ */
+float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw);
+
+/**
+ * @brief Read VBAT voltage using CH9 calibration
+ *
+ * @return                      VBAT voltage in V
+ */
+float ADC_GetVBatVoltage(void);
 
 
 #endif

--- a/src/FWlib/peripheral_pwm.c
+++ b/src/FWlib/peripheral_pwm.c
@@ -243,7 +243,7 @@ void PWM_SetStepCnt(const uint8_t channel,uint32_t cnt)
 void PWM_SetStepTarget(const uint8_t channel,uint32_t target)
 {
     uint32_t mask = APB_PWM->STEPChannels[channel].step1 & ~(0xFFFFFUL);
-    APB_PWM->STEPChannels[channel].step0 = mask | target;
+    APB_PWM->STEPChannels[channel].step1 = mask | target;
 }
 
 void IR_CycleCarrierSetup(uint8_t channel, uint8_t carry_channel, uint32_t frequency, uint32_t duty)

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2040,6 +2040,13 @@ int SYSCTRL_Init(void)
     else
         ROM_PLLinUse(0, 0, 0, 0);
 
+//    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x38) |= 0x5<<15;
+//    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x30) |= (0x5<<28) | (0x1a<<5);
+//    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x34) |= 0x30<<14;
+
+//    set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x1c), 0x1d, 6, 16);
+////    set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x3c), 150, 8, 24);
+    
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x38) |= 0x5<<15;
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x30) |= (0x5<<28) | (0x1a<<5);
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x34) |= 0x30<<14;

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2040,7 +2040,7 @@ uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
     SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_PWM);
     set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 0);
     set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 3);
-    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) &= ~(0xff<<24);
+    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) &= ~(0xfful<<24);
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) |= clc<<24;
 
     APB_SYSCTRL->DmaCtrl[1] = 0x8 | (0x9<<4);
@@ -2325,7 +2325,7 @@ SYSCTRL_ResetSource SYSCTRL_GetResetSource(void)
     uint32_t val;
     val = *(volatile uint32_t*)(APB_SYSCTRL_BASE + 0x218);
 
-    return (val>>1)&0x3f;
+    return (SYSCTRL_ResetSource)((val>>1)&0x3f);
 }
 
 #endif

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2024,41 +2024,133 @@ void SYSCTRL_ICacheFlush(void)
     SYSCTRL_CacheFlush(IC_BASE);
 }
 
+uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
+{
+    uint32_t pcap[4];
+    uint32_t mode;
+    uint32_t hclk_select;
+    float freq;
+    DMA_Descriptor descriptor __attribute__((aligned(8)));
+    uint8_t enabled = io_read(AON1_CTRL_BASE + 0x28) & 1;
+    if (!enabled) SYSCTRL_EnablePLL(1);
+    hclk_select = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)>>31)&0x1;
+    mode = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)>>20)&0XFF;
+    if ((mode!=SYSCTRL_CLK_PLL_DIV_3) || (!hclk_select)) SYSCTRL_SelectHClk(SYSCTRL_CLK_PLL_DIV_3);
+    SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_DMA);
+    SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_PWM);
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 0);
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 3);
+    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) &= ~(0xff<<24);
+    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) |= clc<<24;
+
+    APB_SYSCTRL->DmaCtrl[1] = 0x8 | (0x9<<4);
+    APB_DMA->Channels[0].Descriptor.Ctrl = (0x8<<8)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
+    APB_DMA->Channels[0].Descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
+    APB_DMA->Channels[0].Descriptor.DstAddr = (uint32_t)pcap;
+    APB_DMA->Channels[0].Descriptor.TranSize = 2;
+    APB_DMA->Channels[0].Descriptor.Next = &descriptor;
+    descriptor.Ctrl = (0x0<<4)|(0x8<<8)|(0x2<<12)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
+    descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
+    descriptor.DstAddr = (uint32_t)&pcap[2];
+    descriptor.TranSize = 1000*2-1;
+    descriptor.Next = 0;
+    APB_DMA->Channels[0].Descriptor.Ctrl |= 0x1;
+    APB_PWM->Channels[0].Ctrl0 = (0x6<<7)|(0x1<<21)|(0x1<<20);
+    APB_PWM->PCAPChannels[0].Ctrl0 |= 0x1;
+    APB_PWM->CapCntEn = 0x1;
+    APB_PWM->Channels[0].Ctrl0 |= 0x1<<6;
+    while (!(APB_DMA->IntStatus & (0x1<<16)));
+    APB_DMA->IntStatus = 0xffffffff;
+    APB_PWM->Channels[0].Ctrl0 &= ~(0x1<<6);
+    APB_PWM->Channels[0].Ctrl0 &= ~(0x1<<20);
+    APB_PWM->Channels[0].Ctrl0 |= 0x1<<15;
+    freq = (float)(1000UL*24000UL)/((float)pcap[2] - (float)pcap[0]);
+    APB_SYSCTRL->DmaCtrl[1] = 0x76543210;
+
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 0, 0);
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 0, 3);
+    SYSCTRL_SetClkGate(SYSCTRL_ITEM_APB_DMA);
+    SYSCTRL_SetClkGate(SYSCTRL_ITEM_APB_PWM);
+
+    if (!enabled) SYSCTRL_EnablePLL(0);
+    if (!hclk_select) SYSCTRL_SelectHClk(SYSCTRL_CLK_SLOW);
+    else if (mode!=SYSCTRL_CLK_PLL_DIV_3) SYSCTRL_SelectHClk((SYSCTRL_ClkMode)mode);
+
+    return (uint32_t)(freq*1000);
+}
+
+uint32_t SYSCTRL_RC2MTune(uint32_t freq)
+{
+    uint32_t start;
+    uint32_t end;
+    uint32_t mid;
+
+    uint32_t min;
+    uint32_t max;
+
+    uint32_t Freq;
+
+    min = 0;
+    max = 0xff;
+
+    start = min;
+    end = max;
+
+    while(start < end){
+        mid = (start + end) / 2;
+        Freq = SYSCTRL_RC2MCalib(mid);
+        if(Freq == freq){
+            break;
+        }
+        else if(Freq < freq){
+            start = mid + 1;
+        }
+        else{
+            end = mid - 1;
+        }
+    }
+    if(end < min){
+        end = min;
+    }
+    if(start > max){
+        start = max;
+    }
+
+    Freq = SYSCTRL_RC2MCalib(end);
+    if(Freq > freq){
+        Freq = SYSCTRL_RC2MCalib(start);
+    }
+
+    return Freq;
+}
+
 int SYSCTRL_Init(void)
 {
     typedef void    (*rom_PowerOnSeq)(uint8_t XOMode, uint8_t XOModeFast, uint8_t SeqFastMode);
     typedef void    (*rom_PowerDownSeq)(void);
     typedef void    (*rom_PLLinUse)(uint8_t PLLEn, uint8_t XOMode, uint8_t XOModeFast, uint8_t SeqFastMode);
+    typedef void       (*rom_PowerDownSeqPatch             )(void);
+
     #define ROM_PLLinUse    ((rom_PLLinUse)(0x00000e21))
-    #define ROM_PowerOnSeq      ((rom_PowerOnSeq)(0x0000101d))
-    #define ROM_PowerDownSeq    ((rom_PowerDownSeq)(0x00000f05))
+    #define ROM_PowerOnSeq          ((rom_PowerOnSeq)(0x0000101d))
+    #define ROM_PowerDownSeq        ((rom_PowerDownSeq)(0x00000f05))
+    #define ROM_PowerDownSeqPatch   ((rom_PowerDownSeqPatch)(0x00001001))
+    SYSCTRL_RC2MTune(1500000);
     ROM_PowerOnSeq(1, 1, 1);
     ROM_PowerDownSeq();
+    ROM_PowerDownSeqPatch();
 
     if (io_read(AON1_CTRL_BASE + 0x28) & 1)
         ROM_PLLinUse(1, 1, 1, 1);
     else
         ROM_PLLinUse(0, 0, 0, 0);
 
-//    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x38) |= 0x5<<15;
-//    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x30) |= (0x5<<28) | (0x1a<<5);
-//    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x34) |= 0x30<<14;
-
-//    set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x1c), 0x1d, 6, 16);
-////    set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x3c), 150, 8, 24);
-    
-    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x38) |= 0x5<<15;
-    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x30) |= (0x5<<28) | (0x1a<<5);
-    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x34) |= 0x30<<14;
-
     set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x1c), 0x1d, 6, 16);
-    set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x3c), 150, 8, 24);
-
     set_reg_bit((volatile uint32_t *)(AON2_CTRL_BASE + 0x4),0,18);
     set_reg_bit((volatile uint32_t *)(AON1_CTRL_BASE + 0x14),0,26);
     set_reg_bit((volatile uint32_t *)(AON1_CTRL_BASE + 0x10),0,10);
 
-    // TODO:
+    Vcore_calib();
     return 0;
 }
 

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2124,6 +2124,12 @@ uint32_t SYSCTRL_RC2MTune(uint32_t freq)
     return Freq;
 }
 
+__attribute__((weak)) int Vcore_calib(void)
+{
+    // add `eflash.c` to the project!
+    return -1;
+}
+
 int SYSCTRL_Init(void)
 {
     typedef void    (*rom_PowerOnSeq)(uint8_t XOMode, uint8_t XOModeFast, uint8_t SeqFastMode);

--- a/src/FWlib/peripheral_sysctrl.h
+++ b/src/FWlib/peripheral_sysctrl.h
@@ -7,6 +7,7 @@ extern "C" {	/* allow C++ to use these headers */
 
 #include "ingsoc.h"
 #include "peripheral_pinctrl.h"
+#include "eflash.h"
 
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)
 


### PR DESCRIPTION
feat(eflash):

 implement mass-production FT data migration, calibration, VCOR and ADC value calculation; fix issue where single flash write >32 bytes may only succeed in writing 16 bytes (recommend keeping writes ≤32 bytes to avoid performance impact from non-DMA splitting or DMA channel 0 usage); ensure flash clock <4x HCLK when using DMA

feat(sysctrl): 

enhance SYSCTRL_Init with FT core voltage calibration and FT data migration for first power-up

feat(adc): 

add interface to retrieve FT calibration data; remove redundant hardware calibration logic

fix(pwm): 

correct erroneous operation in PWM_SetStepTarget interface