### PR TITLE
fix iic.c and eflash.c

### DIFF
--- a/src/BSP/board.c
+++ b/src/BSP/board.c
@@ -278,6 +278,9 @@ void reboot_i2c_module()
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
     SYSCTRL_ResetBlock(SYSCTRL_ITEM_APB_I2C0);
     SYSCTRL_ReleaseBlock(SYSCTRL_ITEM_APB_I2C0);
+#elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+    SYSCTRL_ResetBlock(SYSCTRL_ITEM_APB_I2C0);
+    SYSCTRL_ReleaseBlock(SYSCTRL_ITEM_APB_I2C0);
 #endif
     i2c_init(I2C_PORT);
 }

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -753,7 +753,7 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
 
 static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
     uint16_t crc = 0xFFFF;
-	  int i;
+    int i;
     while (usDataLen--) {
         crc ^= *puchMsg++;
         for (i = 0; i < 8; i++) {
@@ -789,6 +789,7 @@ static uint16_t calc_factory_calib_crc16(const factory_calib_data_t *calib)
 static void copy_security_bytes(uint8_t *dst, uint32_t src, uint32_t size)
 {
     uint32_t word;
+    FLASH_PRE_OPS()
     while (size >= 4U)
     {
         word = read_flash_security(src);
@@ -803,6 +804,7 @@ static void copy_security_bytes(uint8_t *dst, uint32_t src, uint32_t size)
         word = read_flash_security(src);
         memcpy(dst, &word, size);
     }
+    FLASH_POST_OPS();
 }
 
 static int factory_data_ready(void)
@@ -923,12 +925,16 @@ int flash_prepare_factory_data(void)
     flash_read_protection_status(&region, &reverse_selection);
     flash_enable_write_protection(FLASH_REGION_NONE, 0);
 
+    FLASH_PRE_OPS();
+
     if(read_flash_security(FACTORY_DIE_INFO_SRC_ADDR) == 0xfffffffful)
     {
         // no ft data;
         flash_enable_write_protection((flash_region_t)region, reverse_selection);
+        FLASH_POST_OPS();
         return 1;
     }
+    FLASH_POST_OPS();
 
     copy_security_bytes((uint8_t *)&die_info,
                         FACTORY_DIE_INFO_SRC_ADDR,

--- a/src/BSP/iic.c
+++ b/src/BSP/iic.c
@@ -187,6 +187,7 @@ int I2C_MasterWrite(I2C_TypeDef *I2C_BASE, I2C_AddressingMode AddrMode, uint16_t
     int timeout = I2C_HW_TIME_OUT;
 
     I2C_Config(I2C_BASE, I2C_ROLE_MASTER, AddrMode, Addr);
+    I2C_BASE->Cmd = I2C_COMMAND_CLEAR_FIFO;
 
     I2C_BASE->Ctrl = DataCnt
                     | (I2C_TRANSACTION_MASTER2SLAVE << bsI2C_CTRL_TRANSACTION_DIR)
@@ -194,12 +195,21 @@ int I2C_MasterWrite(I2C_TypeDef *I2C_BASE, I2C_AddressingMode AddrMode, uint16_t
 
     I2C_BASE->IntEn = (1 << I2C_INT_CMPL) | (1 << I2C_INT_FIFO_EMPTY);
 
-    I2C_BASE->Cmd = 0x1;
-
-    for (i = 0; i < DataCnt; i++) {
-        while_with_timeout(I2C_FifoFull(I2C_BASE)) ;
-        I2C_BASE->Data = Data[i];
+    if(I2C_FIFO_DEPTH > DataCnt) {
+        for (i = 0; i < DataCnt; i++) 
+            I2C_BASE->Data = Data[i];
+        I2C_BASE->Cmd = 0x1;
     }
+    else {
+        for (i = 0; i < I2C_FIFO_DEPTH/2; i++) 
+            I2C_BASE->Data = Data[i];
+        I2C_BASE->Cmd = 0x1;
+        for (; i < DataCnt; i++) {
+            while_with_timeout(I2C_FifoFull(I2C_BASE)) ;
+            I2C_BASE->Data = Data[i];
+        }
+    }
+    
     I2C_BASE->IntEn = (1 << I2C_INT_CMPL);
     while_with_timeout(I2C_TransactionComplete(I2C_BASE) == 0);
     I2C_BASE->IntEn = 0;
@@ -212,6 +222,7 @@ int I2C_MasterRead(I2C_TypeDef *I2C_BASE, I2C_AddressingMode AddrMode, uint16_t 
     uint8_t i;
     int timeout = I2C_HW_TIME_OUT;
     I2C_Config(I2C_BASE, I2C_ROLE_MASTER, AddrMode, Addr);
+    I2C_BASE->Cmd = I2C_COMMAND_CLEAR_FIFO;
 
     I2C_BASE->Ctrl = DataCnt
                     | (I2C_TRANSACTION_SLAVE2MASTER << bsI2C_CTRL_TRANSACTION_DIR)


### PR DESCRIPTION
- fix(iic): resolve I²C communication failure on 20-series chips caused by incorrect operation timing; ensure data is written to FIFO before enabling transmission

- fix(eflash): disable Flash CONTINUOUS MODE before copying security data to prevent occasional hang during operation