### PR TITLE
fix some issues when building using `-O3` optimization etc

### DIFF
--- a/bundles/rom/inc/platform_def.h
+++ b/bundles/rom/inc/platform_def.h
@@ -8,8 +8,8 @@
 
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
-    #define   SYS_MEMORY_SIZE_KiB   48
-    #define SHARE_MEMORY_SIZE_KiB    8
+    #define   SYS_MEMORY_SIZE_KiB   40
+    #define SHARE_MEMORY_SIZE_KiB   16
 
 #else
     #error unknown or unsupported chip family

--- a/examples-gcc/peripheral_console_liteos/makefile.conf
+++ b/examples-gcc/peripheral_console_liteos/makefile.conf
@@ -1,4 +1,4 @@
-ING_SRC_INC=-I $(ING_REL)/src/BSP -I $(ING_REL)/src/FWlib -I $(ING_REL)/src/StartUP/ing916 -I $(ING_REL)/src/Tools -I $(ING_REL)/src
+ING_SRC_INC=-I $(ING_REL)/src/BSP -I $(ING_REL)/src/FWlib -I $(ING_REL)/src/StartUP/ing20 -I $(ING_REL)/src/Tools -I $(ING_REL)/src
 ING_BUNDLE_INC=-I $(ING_BUNDLE) -I $(ING_BUNDLE)/os -I $(CMSIS_INC) $(OS_INC)
 
 OBJ_PATH=obj
@@ -17,7 +17,7 @@ USE_SEMIHOST=--specs=rdimon.specs
 USE_NOHOST=--specs=nosys.specs
 
 # Options for specific architecture
-ARCH_FLAGS=-mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
+ARCH_FLAGS=-mthumb -mcpu=cortex-m3
 
 PREFIX	 = @arm-none-eabi-
 CC      := $(PREFIX)gcc
@@ -48,7 +48,7 @@ LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(SYMDEFS) $(GC) $(MAP)
 # to enable float point value printf
 # LFLAGS+=-u _printf_float
 
-release: CFLAGS += -O0
+release: CFLAGS += -O3
 release: $(APPNAME).bin
 
 debug: CFLAGS += -DDEBUG -g -O0

--- a/examples-gcc/peripheral_console_liteos/src/gen_os_impl.c
+++ b/examples-gcc/peripheral_console_liteos/src/gen_os_impl.c
@@ -43,7 +43,7 @@ gen_handle_t port_timer_create(
     void (*timer_cb)(void *))
 {
     UINT32 *id = (UINT32 *)port_malloc(sizeof(UINT32));
-    LOS_SwtmrCreate(LOS_MS2Tick(timeout_in_ms), LOS_SWTMR_MODE_NO_SELFDELETE, (SWTMR_PROC_FUNC)timer_cb, id, *(UINT32 *)user_data);
+    LOS_SwtmrCreate(LOS_MS2Tick(timeout_in_ms), LOS_SWTMR_MODE_NO_SELFDELETE, (SWTMR_PROC_FUNC)timer_cb, id, (UINTPTR)user_data);
     return (gen_handle_t)id;
 }
 
@@ -269,7 +269,7 @@ const gen_os_driver_t *os_impl_get_driver(void)
     return &gen_os_driver;
 }
 
-#define _SYSTICK_PRI (*(uint8_t *)(0xE000ED23UL))
+#define _SYSTICK_PRI (*(volatile uint8_t *)(0xE000ED23UL))
 
 /* Constants required to manipulate the core.  Registers first... */
 #define portNVIC_SYSTICK_CTRL_REG               (*((volatile uint32_t *)0xe000e010))

--- a/examples/data_logger/src/mmc_spi.c
+++ b/examples/data_logger/src/mmc_spi.c
@@ -215,6 +215,10 @@ static void init_spi (void)
 
     PINCTRL_SelSpiPins(SPI_CH, SPI_PIN_SCK, IO_NOT_A_PIN, IO_NOT_A_PIN,
         IO_NOT_A_PIN, SPI_PIN_MISO, SPI_PIN_MOSI);
+    
+    #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+    SYSCTRL_SelectSpiClkDiv(SPI_CH, SYSCTRL_CLK_SLOW, 1);
+    #endif
 
     SET_DATA_SIZE(8);
 
@@ -320,8 +324,9 @@ static int wait_ready (	/* 1:Ready, 0:Timeout */
 static void deselect (void)
 {
     CS_HIGH();		/* Set CS# high */
+    #if ((INGCHIPS_FAMILY == INGCHIPS_FAMILY_916) || (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20))
     xchg_spi(0xFF);	/* Dummy clock (force DO hi-z for multiple slave SPI) */
-
+    #endif
 }
 
 

--- a/examples/data_logger/src/mmc_spi.c
+++ b/examples/data_logger/src/mmc_spi.c
@@ -189,8 +189,8 @@ void reinit_spi(void)
         .eMasterSlaveMode = SPI_SLVMODE_MASTER_MODE,
         .eReadWriteMode = SPI_TRANSMODE_WRITE_READ_SAME_TIME,
         .eQuadMode = SPI_DUALQUAD_REGULAR_MODE,
-        .eWriteTransCnt = 0,
-        .eReadTransCnt = 0,
+        .eWriteTransCnt = 1,
+        .eReadTransCnt = 1,
         .eAddrEn = SPI_ADDREN_DISABLE,
         .eCmdEn = SPI_CMDEN_DISABLE,
         .SlaveDataOnly = SPI_SLVDATAONLY_DISABLE,
@@ -209,7 +209,6 @@ static void init_spi (void)
     SYSCTRL_ClearClkGateMulti((1 << SYSCTRL_ClkGate_AHB_SPI0)
                             | (1 << SYSCTRL_ClkGate_APB_GPIO0)
                             | (1 << SYSCTRL_ITEM_APB_PinCtrl));
-
     PINCTRL_SetPadMux(SPI_PIN_CS, IO_SOURCE_GPIO);
     GIO_SetDirection(SPI_PIN_CS, GIO_DIR_OUTPUT);      // set CS output
 
@@ -234,18 +233,27 @@ static void rcvr_spi_multi (
 )
 {
     DWORD d;
-
-    SET_DATA_SIZE(16);
-    apSSP_SetTransMode(SPI_SSP, SPI_TRANSMODE_READ_ONLY);
-    apSSP_SetTransferControlRdTranCnt(SPI_SSP, btr/2);
-    apSSP_WriteCmd(SPI_SSP, 0, 0);
+    DWORD i;
+    UINT tx_words = btr / 2; 
+    UINT rx_words = btr / 2; 
     
-    do {					/* Receive the data block into buffer */
-        while (apSSP_RxFifoEmpty(SPI_SSP)) ;
-        apSSP_ReadFIFO(SPI_SSP, &d);
-        buff[1] = d; buff[0] = d >> 8;
-        buff += 2;
-    } while (btr -= 2);
+    SET_DATA_SIZE(16);
+    apSSP_SetTransferControlWrTranCnt(SPI_SSP, tx_words);
+    apSSP_SetTransferControlRdTranCnt(SPI_SSP, rx_words);
+    apSSP_WriteCmd(SPI_SSP, 0, 0);
+    while (tx_words > 0 || rx_words > 0) {
+        
+        while (!apSSP_TxFifoFull(SPI_SSP) && tx_words > 0) {
+            apSSP_WriteFIFO(SPI_SSP, 0xffff);
+            tx_words--;
+        }
+        while (!apSSP_RxFifoEmpty(SPI_SSP) && rx_words > 0) {
+            apSSP_ReadFIFO(SPI_SSP, &d);
+            buff[1] = d; buff[0] = d >> 8; 
+            buff += 2;
+            rx_words--;
+        }
+    }
     SET_DATA_SIZE(8);
 }
 
@@ -258,17 +266,26 @@ static void xmit_spi_multi (
 {
     WORD d;
     DWORD t;
+    UINT tx_words = btx / 2;
+    UINT rx_words = btx / 2; 
+
     SET_DATA_SIZE(16);
-    
-    apSSP_SetTransMode(SPI_SSP, SPI_TRANSMODE_WRITE_ONLY);
-    apSSP_SetTransferControlWrTranCnt(SPI_SSP, btx/2);
+    apSSP_SetTransferControlWrTranCnt(SPI_SSP, tx_words);
+    apSSP_SetTransferControlRdTranCnt(SPI_SSP, rx_words);
     apSSP_WriteCmd(SPI_SSP, 0, 0);
-    do {
-        d = buff[0] << 8 | buff[1]; buff += 2;	/* Word to send next */
-        while (apSSP_TxFifoFull(SPI_SSP)) ;
-        apSSP_WriteFIFO(SPI_SSP, d);
-    } while (btx -= 2);
-    while (!apSSP_TxFifoEmpty(SPI_SSP)) __NOP();
+    while (tx_words > 0 || rx_words > 0) {
+        while (!apSSP_TxFifoFull(SPI_SSP) && tx_words > 0) {
+            d = buff[0] << 8 | buff[1]; 
+            buff += 2;
+            apSSP_WriteFIFO(SPI_SSP, d);
+            tx_words--;
+        }
+        while (!apSSP_RxFifoEmpty(SPI_SSP) && rx_words > 0) {
+            apSSP_ReadFIFO(SPI_SSP, &t);
+            rx_words--;
+        }
+    }
+    
     SET_DATA_SIZE(8);
 }
 #endif
@@ -281,8 +298,8 @@ static BYTE xchg_spi (
     DWORD t;
     apSSP_SetTransferControlWrTranCnt(SPI_SSP, 1);
     apSSP_SetTransferControlRdTranCnt(SPI_SSP, 1);
-    apSSP_WriteCmd(SPI_SSP, 0, 0);
     apSSP_WriteFIFO(SPI_SSP, dat);
+    apSSP_WriteCmd(SPI_SSP, 0, 0);
     while (apSSP_RxFifoEmpty(SPI_SSP)) ;
     apSSP_ReadFIFO(SPI_SSP, &t);
     return t;
@@ -322,9 +339,8 @@ static int wait_ready (	/* 1:Ready, 0:Timeout */
 static void deselect (void)
 {
     CS_HIGH();		/* Set CS# high */
-    #if ((INGCHIPS_FAMILY == INGCHIPS_FAMILY_916) || (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20))
     xchg_spi(0xFF);	/* Dummy clock (force DO hi-z for multiple slave SPI) */
-    #endif
+
 }
 
 
@@ -544,7 +560,6 @@ DRESULT disk_read (
     if (Stat & STA_NOINIT) return RES_NOTRDY;	/* Check if drive is ready */
 
     if (!(CardType & CT_BLOCK)) sect *= 512;	/* LBA ot BA conversion (byte addressing cards) */
-
     if (count == 1) {	/* Single sector read */
         if ((send_cmd(CMD17, sect) == 0)	/* READ_SINGLE_BLOCK */
             && rcvr_datablock(buff, 512)) {

--- a/examples/data_logger/src/mmc_spi.c
+++ b/examples/data_logger/src/mmc_spi.c
@@ -246,7 +246,6 @@ static void rcvr_spi_multi (
         buff[1] = d; buff[0] = d >> 8;
         buff += 2;
     } while (btr -= 2);
-    
     SET_DATA_SIZE(8);
 }
 
@@ -266,11 +265,10 @@ static void xmit_spi_multi (
     apSSP_WriteCmd(SPI_SSP, 0, 0);
     do {
         d = buff[0] << 8 | buff[1]; buff += 2;	/* Word to send next */
-        while (apSSP_RxFifoEmpty(SPI_SSP)) ;
+        while (apSSP_TxFifoFull(SPI_SSP)) ;
         apSSP_WriteFIFO(SPI_SSP, d);
-        apSSP_WriteCmd(SPI_SSP, 0, 0);
     } while (btx -= 2);
-
+    while (!apSSP_TxFifoEmpty(SPI_SSP)) __NOP();
     SET_DATA_SIZE(8);
 }
 #endif

--- a/examples/data_logger/src/mmc_spi.c
+++ b/examples/data_logger/src/mmc_spi.c
@@ -189,8 +189,8 @@ void reinit_spi(void)
         .eMasterSlaveMode = SPI_SLVMODE_MASTER_MODE,
         .eReadWriteMode = SPI_TRANSMODE_WRITE_READ_SAME_TIME,
         .eQuadMode = SPI_DUALQUAD_REGULAR_MODE,
-        .eWriteTransCnt = 1,
-        .eReadTransCnt = 1,
+        .eWriteTransCnt = 0,
+        .eReadTransCnt = 0,
         .eAddrEn = SPI_ADDREN_DISABLE,
         .eCmdEn = SPI_CMDEN_DISABLE,
         .SlaveDataOnly = SPI_SLVDATAONLY_DISABLE,
@@ -232,23 +232,17 @@ static void rcvr_spi_multi (
     DWORD d;
 
     SET_DATA_SIZE(16);
-
-    apSSP_WriteFIFO(SPI_SSP, 0xffff);
+    apSSP_SetTransMode(SPI_SSP, SPI_TRANSMODE_READ_ONLY);
+    apSSP_SetTransferControlRdTranCnt(SPI_SSP, btr/2);
     apSSP_WriteCmd(SPI_SSP, 0, 0);
-
-    btr -= 2;
+    
     do {					/* Receive the data block into buffer */
         while (apSSP_RxFifoEmpty(SPI_SSP)) ;
         apSSP_ReadFIFO(SPI_SSP, &d);
-        apSSP_WriteFIFO(SPI_SSP, 0xffff);
-        apSSP_WriteCmd(SPI_SSP, 0, 0);
         buff[1] = d; buff[0] = d >> 8;
         buff += 2;
     } while (btr -= 2);
-    while (apSSP_RxFifoEmpty(SPI_SSP)) ;
-    apSSP_ReadFIFO(SPI_SSP, &d);
-    buff[1] = d; buff[0] = d >> 8;			/* Store it */
-
+    
     SET_DATA_SIZE(8);
 }
 
@@ -261,22 +255,17 @@ static void xmit_spi_multi (
 {
     WORD d;
     DWORD t;
-
     SET_DATA_SIZE(16);
-
-    d = buff[0] << 8 | buff[1]; buff += 2;
-    apSSP_WriteFIFO(SPI_SSP, d);
+    
+    apSSP_SetTransMode(SPI_SSP, SPI_TRANSMODE_WRITE_ONLY);
+    apSSP_SetTransferControlWrTranCnt(SPI_SSP, btx/2);
     apSSP_WriteCmd(SPI_SSP, 0, 0);
-    btx -= 2;
     do {
         d = buff[0] << 8 | buff[1]; buff += 2;	/* Word to send next */
         while (apSSP_RxFifoEmpty(SPI_SSP)) ;
-        apSSP_ReadFIFO(SPI_SSP, &t);
         apSSP_WriteFIFO(SPI_SSP, d);
         apSSP_WriteCmd(SPI_SSP, 0, 0);
     } while (btx -= 2);
-    while (apSSP_RxFifoEmpty(SPI_SSP)) ;
-    apSSP_ReadFIFO(SPI_SSP, &t);
 
     SET_DATA_SIZE(8);
 }
@@ -288,9 +277,10 @@ static BYTE xchg_spi (
 )
 {
     DWORD t;
-
-    apSSP_WriteFIFO(SPI_SSP, dat);
+    apSSP_SetTransferControlWrTranCnt(SPI_SSP, 1);
+    apSSP_SetTransferControlRdTranCnt(SPI_SSP, 1);
     apSSP_WriteCmd(SPI_SSP, 0, 0);
+    apSSP_WriteFIFO(SPI_SSP, dat);
     while (apSSP_RxFifoEmpty(SPI_SSP)) ;
     apSSP_ReadFIFO(SPI_SSP, &t);
     return t;

--- a/examples/data_logger/src/profile.c
+++ b/examples/data_logger/src/profile.c
@@ -23,7 +23,7 @@
 #define RING_BUF_SIZE  (1024 * 4)
 #define INVALID_HANDLE 0xffff
 
-static uint8_t the_ring_buf[RING_BUF_SIZE];
+static uint32_t the_ring_buf[RING_BUF_SIZE / sizeof(uint32_t)];
 struct ring_buf *ring_buf_obj;
 
 enum

--- a/examples/io_over_ble_mas/src/buf_io.c
+++ b/examples/io_over_ble_mas/src/buf_io.c
@@ -13,7 +13,7 @@
     #error unknown or unsupported chip family
 #endif
 
-static uint8_t ring_buff_storage[RX_BUFFER_SIZE];
+static uint32_t ring_buff_storage[RX_BUFFER_SIZE / sizeof(uint32_t)];
 static struct ring_buf *ring_buffer;
 
 extern void show_state(const io_state_t state);

--- a/examples/peripheral_battery/src/profile.c
+++ b/examples/peripheral_battery/src/profile.c
@@ -167,6 +167,8 @@ uint16_t read_adc(uint8_t channel)
 
     return adc_calibrate(ADC_SAMPLE_MODE_SLOW, channel, voltage);
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_916)
+    uint32_t data;
+    uint16_t sample;
     ADC_ConvCfg(CONTINUES_MODE, PGA_PARA_1, 1, (SADC_channelId)channel, AVE_NUM, 0,
         SINGLE_END_MODE, LOOP_DELAY(ADC_CLK_MHZ, SAMPLERATE, ADC_CH_NUM));
     ADC_AveInit();
@@ -175,8 +177,7 @@ uint16_t read_adc(uint8_t channel)
     ADC_Start(0);
     ADC_EnableChannel((SADC_channelId)channel, 0);
     ADC_IntEnable(0);
-    uint32_t data;
-    uint16_t sample;
+    
     while (!ADC_GetFifoEmpty()) {
         data = ADC_PopFifoData();
         sample = ADC_GetAveData(data);
@@ -184,6 +185,8 @@ uint16_t read_adc(uint8_t channel)
     ADC_AveDisable();
     return sample;
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
+    uint32_t data;
+    uint16_t sample;
     ADC_ConvCfg(CONTINUES_MODE, (SADC_channelId)channel, AVE_NUM, 0, LOOP_DELAY(ADC_CLK_MHZ, SAMPLERATE, ADC_CH_NUM));
     ADC_AveInit();
     ADC_Start(1);
@@ -191,8 +194,7 @@ uint16_t read_adc(uint8_t channel)
     ADC_Start(0);
     ADC_EnableChannel((SADC_channelId)channel, 0);
     ADC_IntEnable(0);
-    uint32_t data;
-    uint16_t sample;
+    
     while (!ADC_GetFifoEmpty()) {
         data = ADC_PopFifoData();
         sample = ADC_GetAveData(data);
@@ -205,14 +207,14 @@ uint16_t read_adc(uint8_t channel)
 #endif
 }
 
-uint8_t *battery_level = NULL;
+volatile uint8_t *battery_level = NULL;
 
 #define ADC_CHANNEL    4
 
 static void update_battery_status(void)
 {
     uint16_t voltage = read_adc(ADC_CHANNEL);
-    printf("U = %d", voltage);
+    platform_printf("U = %d", voltage);
     // level is reported by comparing max & min voltage
     // for DEMO only
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)

--- a/src/BSP/bsp_usb_cdc_acm.c
+++ b/src/BSP/bsp_usb_cdc_acm.c
@@ -10,23 +10,23 @@
 #define RX_BUFFER_SIZE      (1024)
 #endif
 
-static uint8_t ring_buff_storage_tx[RX_BUFFER_SIZE];
+static uint32_t ring_buff_storage_tx[RX_BUFFER_SIZE / sizeof(uint32_t)];
 static struct ring_buf *ring_buffer_tx;
 static int cb_ring_buf_peek_data_tx(const void *data, int len, int has_more, void *extra);
 
 /* variables and functions area */
 const USB_DEVICE_DESCRIPTOR_REAL_T DeviceDescriptor __attribute__ ((aligned (4))) = USB_DEVICE_DESCRIPTOR;
 
-const BSP_USB_DESC_STRUCTURE_T ConfigDescriptor __attribute__ ((aligned (4))) = { 
-    USB_CONFIG_DESCRIPTOR, 
-    USB_INTERFACE_0_DESCRIPTOR, 
-    USB_HEADER_FUNCTIONAL_DESCRIPTOR, 
-    USB_CALL_MANAGEMENT_FUNCTIONAL_DESCRIPTOR, 
+const BSP_USB_DESC_STRUCTURE_T ConfigDescriptor __attribute__ ((aligned (4))) = {
+    USB_CONFIG_DESCRIPTOR,
+    USB_INTERFACE_0_DESCRIPTOR,
+    USB_HEADER_FUNCTIONAL_DESCRIPTOR,
+    USB_CALL_MANAGEMENT_FUNCTIONAL_DESCRIPTOR,
     USB_ABSTRACT_CONTROL_MANAGEMENT_FUNCTIONAL_DESCRIPTOR,
     USB_UNION_DESCRIPTOR_FUNCTIONAL_DESCRIPTOR,
     USB_EP_CDC_INI_DESCRIPTOR,
     USB_INTERFACE_1_DESCRIPTOR,
-    USB_EP_CDC_BULK_OUT_DESCRIPTOR, 
+    USB_EP_CDC_BULK_OUT_DESCRIPTOR,
     USB_EP_CDC_BULK_IN_DESCRIPTOR
 };
 
@@ -382,7 +382,7 @@ static uint32_t bsp_usb_event_handler(USB_EVNET_HANDLER_T *event)
               if(USB_CDC_Var.cmdSetLineCoding)
               {
                 bsp_cdc_acm_setlinecoding();
-                USB_CDC_Var.cmdSetLineCoding = 0;                
+                USB_CDC_Var.cmdSetLineCoding = 0;
               }
               break;
               case EP_CDC_BULK_OUT:

--- a/src/FWlib/peripheral_ssp.c
+++ b/src/FWlib/peripheral_ssp.c
@@ -228,10 +228,7 @@ void apSSP_WriteFIFO(SSP_TypeDef * SSP_Ptr, uint16_t data)
 /*====================================================================*/
 uint16_t apSSP_ReadFIFO(SSP_TypeDef * SSP_Ptr)
 {
-	uint16_t data;
-	data = SSP_Ptr->DataRegister;
-    __DSB();
-	return data;
+	return SSP_Ptr->DataRegister;
 }
 
 /*====================================================================*/
@@ -372,7 +369,6 @@ void apSSP_WriteCmd(SSP_TypeDef *SPI_BASE, uint32_t Addr, uint32_t Cmd)
 void apSSP_ReadFIFO(SSP_TypeDef *SPI_BASE, uint32_t *Data)
 {
     *Data = SPI_BASE->Data;
-    __DSB();
 }
 
 /*====================================================================*/

--- a/src/FWlib/peripheral_ssp.c
+++ b/src/FWlib/peripheral_ssp.c
@@ -230,6 +230,7 @@ uint16_t apSSP_ReadFIFO(SSP_TypeDef * SSP_Ptr)
 {
 	uint16_t data;
 	data = SSP_Ptr->DataRegister;
+    __DSB();
 	return data;
 }
 
@@ -371,6 +372,7 @@ void apSSP_WriteCmd(SSP_TypeDef *SPI_BASE, uint32_t Addr, uint32_t Cmd)
 void apSSP_ReadFIFO(SSP_TypeDef *SPI_BASE, uint32_t *Data)
 {
     *Data = SPI_BASE->Data;
+    __DSB();
 }
 
 /*====================================================================*/

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2026,58 +2026,44 @@ void SYSCTRL_ICacheFlush(void)
 
 uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
 {
-    uint32_t pcap[4];
-    uint32_t mode;
-    uint32_t hclk_select;
-    float freq;
+    static volatile uint32_t pcap[2];
+    uint32_t diff;
+    uint32_t i;
+    
+    uint32_t freq;
     volatile DMA_Descriptor descriptor __attribute__((aligned(8)));
-    uint8_t enabled = io_read(AON1_CTRL_BASE + 0x28) & 1;
-    if (!enabled) SYSCTRL_EnablePLL(1);
-    hclk_select = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)>>31)&0x1;
-    mode = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)>>20)&0XFF;
-    if ((mode!=SYSCTRL_CLK_PLL_DIV_3) || (!hclk_select)) SYSCTRL_SelectHClk(SYSCTRL_CLK_PLL_DIV_3);
-    SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_DMA);
-    SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_PWM);
-    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 0);
-    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 3);
+    
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) &= ~(0xfful<<24);
-    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) |= clc<<24;
+    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) |= (clc&0xff)<<24;
+    APB_PWM->Channels[0].Ctrl0 = (0x6<<7)|(0x1<<21)|(0x1<<20);
+    APB_PWM->PCAPChannels[0].Ctrl0 |= 0x1;
+    APB_PWM->CapCntEn = 0x1;
 
-    APB_SYSCTRL->DmaCtrl[1] = 0x8 | (0x9<<4);
-    memset((void*)&descriptor, 0, sizeof(descriptor));
-    descriptor.Ctrl = (0x0<<4)|(0x8<<8)|(0x2<<12)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
+    descriptor.Ctrl = 0x0|(0x0<<4)|(0x8<<8)|(0x2<<12)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
     descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
-    descriptor.DstAddr = (uint32_t)&pcap[2];
+    descriptor.DstAddr = (uint32_t)&pcap[1];
     descriptor.TranSize = 1000*2-1;
     descriptor.Next = 0;
-    APB_DMA->Channels[0].Descriptor.Ctrl = (0x8<<8)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
+    
+    APB_DMA->Channels[0].Descriptor.Ctrl = 0x0|(0x8<<8)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
     APB_DMA->Channels[0].Descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
     APB_DMA->Channels[0].Descriptor.DstAddr = (uint32_t)pcap;
     APB_DMA->Channels[0].Descriptor.TranSize = 2;
     APB_DMA->Channels[0].Descriptor.Next = (DMA_Descriptor*)&descriptor;
     __DSB();
     APB_DMA->Channels[0].Descriptor.Ctrl |= 0x1;
-    APB_PWM->Channels[0].Ctrl0 = (0x6<<7)|(0x1<<21)|(0x1<<20);
-    APB_PWM->PCAPChannels[0].Ctrl0 |= 0x1;
-    APB_PWM->CapCntEn = 0x1;
     APB_PWM->Channels[0].Ctrl0 |= 0x1<<6;
+    
     while (!(APB_DMA->IntStatus & (0x1<<16)));
     APB_DMA->IntStatus = 0xffffffff;
-    APB_PWM->Channels[0].Ctrl0 &= ~(0x1<<6);
-    APB_PWM->Channels[0].Ctrl0 &= ~(0x1<<20);
-    APB_PWM->Channels[0].Ctrl0 |= 0x1<<15;
-    freq = (float)(1000UL*24000UL)/((float)pcap[2] - (float)pcap[0]);
-    APB_SYSCTRL->DmaCtrl[1] = 0x76543210;
+    __DSB();
+    while ((APB_DMA->IntStatus & (0x1<<16)));
 
-    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 0, 0);
-    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 0, 3);
-    SYSCTRL_SetClkGate(SYSCTRL_ITEM_APB_DMA);
-    SYSCTRL_SetClkGate(SYSCTRL_ITEM_APB_PWM);
-
-    if (!enabled) SYSCTRL_EnablePLL(0);
-    if (!hclk_select) SYSCTRL_SelectHClk(SYSCTRL_CLK_SLOW);
-    else if (mode!=SYSCTRL_CLK_PLL_DIV_3) SYSCTRL_SelectHClk((SYSCTRL_ClkMode)mode);
-
+    diff = pcap[1] - pcap[0];
+    freq = (1000UL * 24000UL) / diff;
+    
+    SYSCTRL_ResetBlock(SYSCTRL_ITEM_APB_PWM);
+    SYSCTRL_ReleaseBlock(SYSCTRL_ITEM_APB_PWM);
     return (uint32_t)(freq*1000);
 }
 
@@ -2091,6 +2077,14 @@ uint32_t SYSCTRL_RC2MTune(uint32_t freq)
     uint32_t max;
 
     uint32_t Freq;
+    
+    uint8_t enabled = io_read(AON1_CTRL_BASE + 0x28) & 1;
+    SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_DMA);
+    SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_PWM);
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 0);
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 3);
+    
+    APB_SYSCTRL->DmaCtrl[1] = 0x8 | (0x9<<4);
 
     min = 0;
     max = 0xff;
@@ -2122,6 +2116,14 @@ uint32_t SYSCTRL_RC2MTune(uint32_t freq)
     if(Freq > freq){
         Freq = SYSCTRL_RC2MCalib(start);
     }
+    
+    APB_PWM->Channels[0].Ctrl0 &= ~(0x1<<20);
+    APB_PWM->PCAPChannels[0].Ctrl0 = 0;
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 0, 0);
+    set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 0, 3);
+    APB_SYSCTRL->DmaCtrl[1] = 0x76543210;
+    SYSCTRL_SetClkGate(SYSCTRL_ITEM_APB_DMA);
+    SYSCTRL_SetClkGate(SYSCTRL_ITEM_APB_PWM);
 
     return Freq;
 }

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2044,17 +2044,18 @@ uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) |= clc<<24;
 
     APB_SYSCTRL->DmaCtrl[1] = 0x8 | (0x9<<4);
-    APB_DMA->Channels[0].Descriptor.Ctrl = (0x8<<8)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
-    APB_DMA->Channels[0].Descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
-    APB_DMA->Channels[0].Descriptor.DstAddr = (uint32_t)pcap;
-    APB_DMA->Channels[0].Descriptor.TranSize = 2;
-    APB_DMA->Channels[0].Descriptor.Next = (DMA_Descriptor*)&descriptor;
     memset((void*)&descriptor, 0, sizeof(descriptor));
     descriptor.Ctrl = (0x0<<4)|(0x8<<8)|(0x2<<12)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
     descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
     descriptor.DstAddr = (uint32_t)&pcap[2];
     descriptor.TranSize = 1000*2-1;
     descriptor.Next = 0;
+    APB_DMA->Channels[0].Descriptor.Ctrl = (0x8<<8)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
+    APB_DMA->Channels[0].Descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
+    APB_DMA->Channels[0].Descriptor.DstAddr = (uint32_t)pcap;
+    APB_DMA->Channels[0].Descriptor.TranSize = 2;
+    APB_DMA->Channels[0].Descriptor.Next = (DMA_Descriptor*)&descriptor;
+    __DSB();
     APB_DMA->Channels[0].Descriptor.Ctrl |= 0x1;
     APB_PWM->Channels[0].Ctrl0 = (0x6<<7)|(0x1<<21)|(0x1<<20);
     APB_PWM->PCAPChannels[0].Ctrl0 |= 0x1;

--- a/src/FWlib/peripheral_sysctrl.h
+++ b/src/FWlib/peripheral_sysctrl.h
@@ -2088,7 +2088,7 @@ void SYSCTRL_SetFastPreDiv(uint8_t div);
 uint32_t SYSCTRL_GetFastPreCLK(void);
 
 /**
- * @brief Set Qdec pclk divider
+ * @brief Set Qdec pclk divider. value range 0-0xf
  * @param[in]   div             divider
  */
 void SYSCTRL_UpdateQdecClk(uint32_t div);

--- a/src/Tools/ring_buf.c
+++ b/src/Tools/ring_buf.c
@@ -1,6 +1,7 @@
 #include "ring_buf.h"
 #include <string.h>
 
+#pragma pack (push, 1)
 struct ring_buf
 {
     void (*highwater_cb)(struct ring_buf *buf);
@@ -12,6 +13,7 @@ struct ring_buf
     uint8_t           watermark_event;
     uint8_t           buffer[1];
 };
+#pragma pack (pop)
 
 struct ring_buf *ring_buf_init(void *buf, int total_size, void (*highwater_cb)(struct ring_buf *buf))
 {
@@ -49,7 +51,7 @@ static int ring_buf_add_buffer(struct ring_buf *buf, const void *buffer, int siz
 
 int ring_buf_peek_data(struct ring_buf *buf, f_ring_peek_data peek_data, void *extra)
 {
-    int r = 0;    
+    int r = 0;
     uint32_t read_next = buf->read_next;
     const uint32_t write_next = buf->write_next;
     while (read_next != write_next)
@@ -97,7 +99,7 @@ int ring_buf_write_data(struct ring_buf *buf, const void *data, int len)
 
     next = ring_buf_add_buffer(buf, data, len, next);
     buf->write_next = next < buf->total_size ? next : 0;
-    
+
     ring_buf_rpt_event(buf, free_size - len);
 
     return len;


### PR DESCRIPTION
* `ring_buf.c`: supported < 4-byte aligned buffer;
* `ring_buf.c`: use 4-byte aligned buffer in examples.
* fix SPI FIFO read API for `-O3`