### PR TITLE
fix(platform): resolve multiple hardware and initialization bugs

### DIFF
--- a/examples/voice_remote_ctrl/src/audio_input_analog.c
+++ b/examples/voice_remote_ctrl/src/audio_input_analog.c
@@ -131,7 +131,7 @@ static uint32_t DMA_cb_isr(void *user_data)
     uint32_t *rr = DMA_PingPongIntProc(&PingPong, CHANNEL_ID);
     uint32_t transSize = DMA_PingPongGetTransSize(&PingPong);
     while (transSize--) {
-        audio_rx_sample((pcm_sample_t)(rr[cnt] & 0xff));
+        audio_rx_sample((pcm_sample_t)(rr[cnt] & 0xffff));
         audio_rx_sample((pcm_sample_t)(rr[cnt] >> 16));
         cnt++;
     }

--- a/src/FWlib/peripheral_qdec.c
+++ b/src/FWlib/peripheral_qdec.c
@@ -258,10 +258,10 @@ void QDEC_IntClear(void)
 
 #elif (INGCHIPS_FAMILY == INGCHIPS_FAMILY_20)
 
-#define NOP_NUME    2
+#define NOP_NUME    4
 __IO uint32_t nop_vale = NOP_NUME;
 
-void Qdec_Nop(uint32_t vale)
+void Qdec_Nop(__IO uint32_t vale)
 {
     while(vale--)
     {

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2152,12 +2152,13 @@ int SYSCTRL_Init(void)
     if (io_read(AON1_CTRL_BASE + 0x28) & 1)
         ROM_PLLinUse(1, 1, 1, 1);
     else
-        ROM_PLLinUse(0, 0, 0, 0);
+        ROM_PLLinUse(0, 1, 1, 1);
 
     set_reg_bits((volatile uint32_t *)(AON1_CTRL_BASE + 0x1c), 0x1d, 6, 16);
     set_reg_bit((volatile uint32_t *)(AON2_CTRL_BASE + 0x4),0,18);
     set_reg_bit((volatile uint32_t *)(AON1_CTRL_BASE + 0x14),0,26);
     set_reg_bit((volatile uint32_t *)(AON1_CTRL_BASE + 0x10),0,10);
+    set_reg_bit((volatile uint32_t *)(AON1_CTRL_BASE + 0x10),0,7);
 
     Vcore_calib();
     return 0;


### PR DESCRIPTION
- Fix the aon1 IO latch issue during the first boot.
- Fix the occasional configuration failure of qdec under O3 optimization.
- Fix the configuration inconsistency issue when sysinit is called without enabling the PLL.
- Fix the low-order bit anomaly in audio data processing.