### PR TITLE
feat: enhance ADC configuration and hardware calibration

### DIFF
--- a/examples/peripheral_battery/src/profile.c
+++ b/examples/peripheral_battery/src/profile.c
@@ -214,7 +214,7 @@ volatile uint8_t *battery_level = NULL;
 static void update_battery_status(void)
 {
     uint16_t voltage = read_adc(ADC_CHANNEL);
-    platform_printf("U = %d", voltage);
+    platform_printf("U = %d\n", voltage);
     // level is reported by comparing max & min voltage
     // for DEMO only
 #if (INGCHIPS_FAMILY == INGCHIPS_FAMILY_918)

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -752,15 +752,21 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
     return r;
 }
 
-static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
+static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen)
+{
     uint16_t crc = 0xFFFF;
     int i;
-    while (usDataLen--) {
+    while (usDataLen--)
+    {
         crc ^= *puchMsg++;
-        for (i = 0; i < 8; i++) {
-            if (crc & 0x0001) {
+        for (i = 0; i < 8; i++)
+        {
+            if (crc & 0x0001)
+            {
                 crc = (crc >> 1) ^ 0xA001;
-            } else {
+            }
+            else
+            {
                 crc >>= 1;
             }
         }
@@ -768,16 +774,16 @@ static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
     return ((crc & 0xFF) << 8) | (crc >> 8);
 }
 
-#define FACTORY_DATA_LOC    (0x02000000 + 0x1000)
-#define FACTORY_DIE_INFO_SRC_ADDR      (0x00000000u)
-#define FACTORY_CALIB_SRC_ADDR         (0x00000100u)
-#define FACTORY_DATA_DIE_INFO          (FACTORY_DATA_LOC)
-#define FACTORY_DATA_CALIB             (FACTORY_DATA_LOC + 0x100)
-#define FACTORY_DATA_CLC               (FACTORY_DATA_LOC + 0x200)
-#define ADC_CAL_CHANNEL_NUM            9
+#define FACTORY_DATA_LOC          (0x02000000 + 0x1000)
+#define FACTORY_DIE_INFO_SRC_ADDR (0x00000000u)
+#define FACTORY_CALIB_SRC_ADDR    (0x00000100u)
+#define FACTORY_DATA_DIE_INFO     (FACTORY_DATA_LOC)
+#define FACTORY_DATA_CALIB        (FACTORY_DATA_LOC + 0x100)
+#define FACTORY_DATA_CLC          (FACTORY_DATA_LOC + 0x200)
+#define ADC_CAL_CHANNEL_NUM       9
 
 
-static uint16_t calc_factory_info_crc16(const die_info_t *info,  uint32_t len)
+static uint16_t calc_factory_info_crc16(const die_info_t *info, uint32_t len)
 {
     return crc16((uint8_t *)info, len - 4);
 }
@@ -875,34 +881,22 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
 
     for (i = 0; i < ADC_CAL_CHANNEL_NUM; ++i)
     {
-        if (i<2)
+        if (i < 2)
         {
-            factory_set_linear_calib(&dst->ch0_8_int_ref[i],
-                                 src->calib_adc.int_vbat33_ain_ch0_8[i][0],
-                                 341.3333f,
-                                 src->calib_adc.int_vbat33_ain_ch0_8[i][1],
-                                 1137.7778f);
-            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
-                                     310.3030f,
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
-                                     1675.6364f);
+            factory_set_linear_calib(&dst->ch0_8_int_ref[i], src->calib_adc.int_vbat33_ain_ch0_8[i][0], 341.3333f,
+                                     src->calib_adc.int_vbat33_ain_ch0_8[i][1], 1137.7778f);
+            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i], src->calib_adc.vbat33_flt_ain_ch0_8[i][0], 310.3030f,
+                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1], 1675.6364f);
         }
         else
         {
-            factory_set_linear_calib(&dst->ch0_8_int_ref[i],
-                                     src->calib_adc.int_vbat33_ain_ch0_8[i][0],
-                                     682.6667f,
-                                     src->calib_adc.int_vbat33_ain_ch0_8[i][1],
-                                     2275.5556f);
-            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
-                                     620.6060f,
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
-                                     3351.2727f);
+            factory_set_linear_calib(&dst->ch0_8_int_ref[i], src->calib_adc.int_vbat33_ain_ch0_8[i][0], 682.6667f,
+                                     src->calib_adc.int_vbat33_ain_ch0_8[i][1], 2275.5556f);
+            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i], src->calib_adc.vbat33_flt_ain_ch0_8[i][0], 620.6060f,
+                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1], 3351.2727f);
         }
     }
-    if(src->calib_adc.version == 0x10)
+    if (src->calib_adc.version == 0x10)
     {
         for (i = 0; i < 8; i++)
         {
@@ -912,10 +906,9 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
             }
             else
                 vref = 1.01f;
-
         }
     }
-    else if(src->calib_adc.version == 0x11)
+    else if (src->calib_adc.version == 0x11)
     {
         for (i = 0; i < 16; i++)
         {
@@ -930,11 +923,8 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
     else
         vref = 1.01f;
 
-    factory_set_vbat_calib(&dst->ch9_vbat,
-                           src->calib_adc.vbat33_flt_int_ch9_11[0],
-                           3.3f,
-                           src->calib_adc.vbat25_flt_int_ch9_11[0],
-                           2.5f, vref);
+    factory_set_vbat_calib(&dst->ch9_vbat, src->calib_adc.vbat33_flt_int_ch9_11[0], 3.3f,
+                           src->calib_adc.vbat25_flt_int_ch9_11[0], 2.5f, vref);
 }
 
 int flash_prepare_factory_data(void)
@@ -975,7 +965,7 @@ int flash_prepare_factory_data(void)
     uint16_t crc = calc_factory_info_crc16(&die_info, sizeof(die_info));
     if (crc != die_info.info_crc16)
         goto check_failed;
-    if(die_info.version == 0x100)
+    if (die_info.version == 0x100)
         crc = calc_factory_calib_crc16(&calib, sizeof(calib) - sizeof(factory_calib_bor_t));
     else
         crc = calc_factory_calib_crc16(&calib, sizeof(calib));

--- a/src/BSP/eflash.h
+++ b/src/BSP/eflash.h
@@ -496,9 +496,10 @@ typedef struct
     uint16_t vdc33[16];
     uint8_t vcore_index;
     uint16_t vcore[16];
-}factory_calib_pmu_t;
+} factory_calib_pmu_t;
 
-typedef struct {
+typedef struct
+{
     uint8_t version;
     uint16_t channel_mask;
     uint16_t int_vbat33_ain_ch0_8[9][2];
@@ -508,7 +509,8 @@ typedef struct {
     uint16_t vbat25_flt_int_ch9_11[3];
 } factory_calib_adc_t;
 
-typedef struct {
+typedef struct
+{
     uint8_t version;
     uint16_t verf;
     uint16_t mic_bias_int;
@@ -523,7 +525,8 @@ typedef struct {
     uint16_t vp_0v5_ext;
 } factory_calib_asdm_t;
 
-typedef struct {
+typedef struct
+{
     uint8_t version;
     uint16_t rest_voltage;
     uint16_t power_voltage;

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -924,6 +924,45 @@ void ADC_HardwareCalibration(void)
     ADC_RegClr(SADC_CFG_0, 9, 1);
     ADC_RegClr(SADC_CFG_2, 2, 1);
     APB_SADC->sadc_int_mask = 0;
+    APB_SADC->sadc_status |= 1 << 22;
+}
+
+void ADC_GetHardwareCalibData(uint8_t Data[7])
+{
+    uint8_t i;
+    ADC_HardwareCalibration();
+    for (i = 0; i < 7; i++)
+    {
+        APB_SADC->sadc_cfg3 &= ~(0x7 << 16);
+        APB_SADC->sadc_cfg3 |= ((i + 1) << 16);
+        Data[i] = (APB_SADC->sadc_cfg3 >> 8) & 0xff;
+    }
+    APB_SADC->sadc_cfg3 &= ~(0x7 << 16);
+}
+
+void ADC_SetHardwareCalibData(uint8_t Data[7])
+{
+    uint8_t i, data;
+
+    ADC_RegWr(SADC_CFG_0, 1, 1);
+    ADC_RegClr(SADC_CFG_0, 28, 1);
+    ADC_RegWr(SADC_CFG_0, 1, 28);
+    for (i = 0; i < 7; i++)
+    {
+        APB_SADC->sadc_cfg3 &= ~(0xff);
+        APB_SADC->sadc_cfg3 |= Data[i] & 0xff;
+        APB_SADC->sadc_cfg3 &= ~(0x7 << 16);
+        APB_SADC->sadc_cfg3 |= ((i + 1) << 16);
+        APB_SADC->sadc_cfg3 |= 1 << 19;
+        do
+        {
+            data = (APB_SADC->sadc_cfg3 >> 8) & 0xff;
+        }
+        while (data != Data[i]);
+    }
+    APB_SADC->sadc_cfg3 &= ~(0x7 << 16);
+    APB_SADC->sadc_cfg3 &= ~(0xff);
+    ADC_RegClr(SADC_CFG_0, 1, 1);
 }
 
 void ADC_Reset(void)
@@ -933,7 +972,7 @@ void ADC_Reset(void)
     ADC_RegWrBits(SADC_CFG_1, 0x100, 0, 32);
     ADC_RegWrBits(SADC_CFG_2, 4 << 16 | 4 << 20 | 0xa << 24, 0, 32);
     ADC_ClrFifo();
-    ADC_RegClr(SADC_STATUS  , 0, 32);
+    ADC_RegClr(SADC_STATUS, 0, 32);
     ADC_RegClr(SADC_INT_MAKS, 0, 32);
 
     ADC_RegWr(SADC_CFG_0, 1, 28);
@@ -947,11 +986,17 @@ void ADC_Reset(void)
 
 void ADC_Start(uint8_t start)
 {
-    if (start) {
-        ADC_RegWr(SADC_CFG_2, 1, 2);
+    if (start)
+    {
         ADC_RegWr(SADC_CFG_0, 1, 1);
-    } else {
+        ADC_RegClr(SADC_CFG_0, 28, 1);
+        ADC_RegWr(SADC_CFG_0, 1, 28);
+        ADC_RegWr(SADC_CFG_2, 1, 2);
+    }
+    else
+    {
         ADC_RegClr(SADC_CFG_2, 2, 1);
+        ADC_RegClr(SADC_CFG_0, 1, 1);
         while (ADC_GetBusyStatus());
     }
 }
@@ -988,6 +1033,9 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
                  uint32_t loopDelay)
 {
     ADC_SetAdcMode(CONVERSION_MODE);
+    ADC_RegWr(SADC_CFG_0, 1, 17);
+    ADC_RegWr(SADC_CFG_0, 1, 18);
+    ADC_RegClr(SADC_CFG_0, 9, 1);
     ADC_SetAdcCtrlMode(ctrlMode);
     ADC_EnableChannel(ch, 1);
     if (enNum) {

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -942,7 +942,7 @@ void ADC_GetHardwareCalibData(uint8_t Data[7])
 
 void ADC_SetHardwareCalibData(uint8_t Data[7])
 {
-    uint8_t i, data;
+    uint8_t i, read_calib;
 
     ADC_RegWr(SADC_CFG_0, 1, 1);
     ADC_RegClr(SADC_CFG_0, 28, 1);
@@ -956,9 +956,9 @@ void ADC_SetHardwareCalibData(uint8_t Data[7])
         APB_SADC->sadc_cfg3 |= 1 << 19;
         do
         {
-            data = (APB_SADC->sadc_cfg3 >> 8) & 0xff;
+            read_calib = (APB_SADC->sadc_cfg3 >> 8) & 0xff;
         }
-        while (data != Data[i]);
+        while (read_calib != Data[i]);
     }
     APB_SADC->sadc_cfg3 &= ~(0x7 << 16);
     APB_SADC->sadc_cfg3 &= ~(0xff);

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -996,8 +996,8 @@ void ADC_Start(uint8_t start)
     else
     {
         ADC_RegClr(SADC_CFG_2, 2, 1);
-        ADC_RegClr(SADC_CFG_0, 1, 1);
         while (ADC_GetBusyStatus());
+        ADC_RegClr(SADC_CFG_0, 1, 1);
     }
 }
 

--- a/src/FWlib/peripheral_adc.h
+++ b/src/FWlib/peripheral_adc.h
@@ -724,6 +724,33 @@ void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
 void ADC_HardwareCalibration(void);
 
 /**
+ * @brief Get hardware calibration data from ADC module
+ *
+ * @note
+ * This function is intended to be called once after power-up to retrieve
+ * the current hardware calibration parameters.
+ * The retrieved data can be stored and later used by 'ADC_SetHardwareCalibData'
+ * to restore calibration without re-running the hardware calibration process.
+ *
+ * @param[out] Data             Buffer to store 7 bytes of calibration data
+ */
+void ADC_GetHardwareCalibData(uint8_t Data[7]);
+
+/**
+ * @brief Set hardware calibration data to ADC module
+ *
+ * @note
+ * Use this function to restore previously saved calibration data after
+ * resetting or restarting the ADC module.
+ * It bypasses the hardware calibration procedure, significantly reducing
+ * initialization time compared to running a full recalibration.
+ * The data should be obtained from 'ADC_GetHardwareCalibData'.
+ *
+ * @param[in] Data              7 bytes of calibration data to be written
+ */
+void ADC_SetHardwareCalibData(uint8_t Data[7]);
+
+/**
  * @brief Convert raw ADC code to calibrated physical value
  *
  * @note


### PR DESCRIPTION
1. Add default configuration to ADC_ConvCfg interface for analog working mode
2. Add new ADC interfaces to support manual read/write of hardware calibration values, reducing power-on hardware calibration time