### PR TITLE
Repair: The adc module adds default parameter

### DIFF
--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -875,32 +875,16 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
 
     for (i = 0; i < ADC_CAL_CHANNEL_NUM; ++i)
     {
-        if (i<2)
-        {
-            factory_set_linear_calib(&dst->ch0_8_int_ref[i],
-                                 src->calib_adc.int_vbat33_ain_ch0_8[i][0],
-                                 341.3333f,
-                                 src->calib_adc.int_vbat33_ain_ch0_8[i][1],
-                                 1137.7778f);
-            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
-                                     310.3030f,
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
-                                     1675.6364f);
-        }
-        else
-        {
-            factory_set_linear_calib(&dst->ch0_8_int_ref[i],
-                                     src->calib_adc.int_vbat33_ain_ch0_8[i][0],
-                                     682.6667f,
-                                     src->calib_adc.int_vbat33_ain_ch0_8[i][1],
-                                     2275.5556f);
-            factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
-                                     620.6060f,
-                                     src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
-                                     3351.2727f);
-        }
+        factory_set_linear_calib(&dst->ch0_8_int_ref[i],
+                                    src->calib_adc.int_vbat33_ain_ch0_8[i][0],
+                                    682.6667f,
+                                    src->calib_adc.int_vbat33_ain_ch0_8[i][1],
+                                    2275.5556f);
+        factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
+                                    src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
+                                    620.6060f,
+                                    src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
+                                    3351.2727f);
     }
     if(src->calib_adc.version == 0x10)
     {
@@ -1062,23 +1046,23 @@ int Vcore_calib(void)
     int i;
     uint8_t vcc_index, lvd_sel;
     uint32_t reg_data;
-    const factory_calib_data_t * calib_data = flash_get_factory_calib_data();
+    const factory_calib_data_t *calib_data = flash_get_factory_calib_data();
     if (calib_data)
     {
         for (i = 0; i < 8; i++)
         {
             if (calib_data->calib_pmu.vaon[i] > 1010)
             {
-                vcc_index =  i+calib_data->calib_pmu.vaon_index;
-                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x30);
-                reg_data &= ~(0xful<<28);
-                reg_data |=(((vcc_index&0x3)|((~vcc_index)&0xc))&0xf)<<28;
-                *(uint32_t*)(AON1_CTRL_BASE+0x30) = reg_data;
+                vcc_index = i + calib_data->calib_pmu.vaon_index;
+                reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x30);
+                reg_data &= ~(0xful << 28);
+                reg_data |= (((vcc_index & 0x3) | ((~vcc_index) & 0xc)) & 0xf) << 28;
+                *(uint32_t *)(AON1_CTRL_BASE + 0x30) = reg_data;
 
-                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x38);
-                reg_data &= ~(0xf<<15);
-                reg_data |= (((vcc_index&0x3)|((~vcc_index)&0xc))&0xf)<<15;
-                *(uint32_t*)(AON1_CTRL_BASE+0x38) = reg_data;
+                reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x38);
+                reg_data &= ~(0xf << 15);
+                reg_data |= (((vcc_index & 0x3) | ((~vcc_index) & 0xc)) & 0xf) << 15;
+                *(uint32_t *)(AON1_CTRL_BASE + 0x38) = reg_data;
                 break;
             }
         }
@@ -1086,11 +1070,11 @@ int Vcore_calib(void)
         {
             if (calib_data->calib_pmu.vcore[i] > 1170)
             {
-                vcc_index =  i+calib_data->calib_pmu.vcore_index;
-                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x30);
-                reg_data &= ~(0x1f<<5);
-                reg_data |=(((vcc_index&0xf)|((~vcc_index)&0x10))&0x1f)<<5;
-                *(uint32_t*)(AON1_CTRL_BASE+0x30) = reg_data;
+                vcc_index = i + calib_data->calib_pmu.vcore_index;
+                reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x30);
+                reg_data &= ~(0x1f << 5);
+                reg_data |= (((vcc_index & 0xf) | ((~vcc_index) & 0x10)) & 0x1f) << 5;
+                *(uint32_t *)(AON1_CTRL_BASE + 0x30) = reg_data;
                 break;
             }
         }
@@ -1098,11 +1082,11 @@ int Vcore_calib(void)
         {
             if (calib_data->calib_pmu.vdc33[i] > 1470)
             {
-                vcc_index =  i+calib_data->calib_pmu.vdc33_index;
-                reg_data = *(uint32_t*)(AON1_CTRL_BASE+0x34);
-                reg_data &= ~(0x3f<<14);
-                reg_data |=(vcc_index&0x3f)<<14;
-                *(uint32_t*)(AON1_CTRL_BASE+0x34) = reg_data;
+                vcc_index = i + calib_data->calib_pmu.vdc33_index;
+                reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x34);
+                reg_data &= ~(0x3f << 14);
+                reg_data |= (vcc_index & 0x3f) << 14;
+                *(uint32_t *)(AON1_CTRL_BASE + 0x34) = reg_data;
                 break;
             }
         }
@@ -1115,6 +1099,30 @@ int Vcore_calib(void)
             *(uint32_t *)(AON1_CTRL_BASE + 0x30) |= lvd_sel << 18;
         }
         return 0;
+    }
+    else
+    {
+        reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x30);
+        reg_data &= ~(0xful << 28);
+        reg_data |= (((6 & 0x3) | ((~6) & 0xc)) & 0xf) << 28;
+        *(uint32_t *)(AON1_CTRL_BASE + 0x30) = reg_data;
+        reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x38);
+        reg_data &= ~(0xf << 15);
+        reg_data |= (((6 & 0x3) | ((~6) & 0xc)) & 0xf) << 15;
+        *(uint32_t *)(AON1_CTRL_BASE + 0x38) = reg_data;
+
+        reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x30);
+        reg_data &= ~(0x1f << 5);
+        reg_data |= (((6 & 0xf) | ((~6) & 0x10)) & 0x1f) << 5;
+        *(uint32_t *)(AON1_CTRL_BASE + 0x30) = reg_data;
+
+        reg_data = *(uint32_t *)(AON1_CTRL_BASE + 0x34);
+        reg_data &= ~(0x3f << 14);
+        reg_data |= 0x1f << 14;
+        *(uint32_t *)(AON1_CTRL_BASE + 0x34) = reg_data;
+
+        *(uint32_t *)(AON1_CTRL_BASE + 0x30) &= ~(0x7 << 18);
+        *(uint32_t *)(AON1_CTRL_BASE + 0x30) |= 6 << 18;
     }
     return -1;
 }

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -12,11 +12,11 @@ static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selec
 
 static uint32_t ClkFreq; //0:16M 1:24M
 
-#define PAGE_SIZE (EFLASH_PAGE_SIZE)
+#define PAGE_SIZE       (EFLASH_PAGE_SIZE)
 #define PAGE_SIZE_SHIFT 13
 
 #define RTC_CHIP_STAT_ADDR (0x40050004)
-#define CLK_FREQ_STAT_POS 3
+#define CLK_FREQ_STAT_POS  3
 
 #define EFLASH_BASE ((uint32_t)0x00004000UL)
 #define EFLASH_SIZE ((uint32_t)0x00080000UL) //512k byte
@@ -25,18 +25,19 @@ static uint32_t ClkFreq; //0:16M 1:24M
 
 static uint32_t prim_irq;
 
-#define FLASH_PRE_OPS()                     \
-    prim_irq = __get_PRIMASK();             \
+#define FLASH_PRE_OPS()                                                                                                \
+    prim_irq = __get_PRIMASK();                                                                                        \
     __disable_irq();
 
-#define FLASH_POST_OPS()                    \
-    if (!prim_irq) __enable_irq()
+#define FLASH_POST_OPS()                                                                                               \
+    if (!prim_irq)                                                                                                     \
+    __enable_irq()
 
 static void init(void)
 {
     FLASH_PRE_OPS();
 
-    ClkFreq = (*(uint32_t volatile*)RTC_CHIP_STAT_ADDR >> CLK_FREQ_STAT_POS) & 0x1;
+    ClkFreq = (*(uint32_t volatile *)RTC_CHIP_STAT_ADDR >> CLK_FREQ_STAT_POS) & 0x1;
     EflashCacheBypass();
     EflashBaseTime();
 #ifdef FOR_ASIC
@@ -81,7 +82,7 @@ int program_flash0(const uint32_t dest_addr, const uint8_t *buffer, uint32_t siz
             uint32_t page_idx = ((addr - EFLASH_BASE) >> PAGE_SIZE_SHIFT) & 0x3f;
             EraseEFlashPage(page_idx);
         }
-        for (i = 0; i<(sz + 3)>> 2; i++)
+        for (i = 0; i < (sz + 3) >> 2; i++)
             EflashProgram(addr + (i << 2), *p32++);
 
         buffer += sz;
@@ -134,15 +135,16 @@ int program_flash(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size
 int write_flash(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
 {
     int r = program_flash0(dest_addr, buffer, size, 0);
-    if (r != 0) return r;
+    if (r != 0)
+        return r;
     r = memcmp((const void *)dest_addr, buffer, size) == 0 ? 0 : 2;
     return r;
 }
 
 int program_fota_metadata(const uint32_t entry, const int block_num, const fota_update_block_t *blocks)
 {
-#define START               (EFLASH_BASE + EFLASH_SIZE + 2 * PAGE_SIZE)
-#define    DEF_UPDATE_FLAG     (0x5A5A5A5A)
+#define START           (EFLASH_BASE + EFLASH_SIZE + 2 * PAGE_SIZE)
+#define DEF_UPDATE_FLAG (0x5A5A5A5A)
 
     uint32_t backup[4];
     uint32_t addr = START - 4;
@@ -162,7 +164,7 @@ int program_fota_metadata(const uint32_t entry, const int block_num, const fota_
     EraseEFlashPage(1);
     *(volatile uint32_t *)(0xc40a0) = 0x0;
 
-    for (i = sizeof(backup) / sizeof(backup[0]) - 1; i >= 0;  i--)
+    for (i = sizeof(backup) / sizeof(backup[0]) - 1; i >= 0; i--)
     {
         EflashProgram(addr, backup[i]);
         addr -= 4;
@@ -185,8 +187,8 @@ int program_fota_metadata(const uint32_t entry, const int block_num, const fota_
     return 0;
 }
 
-#define FACTORY_DATA_LOC    (0x80000 + 0x4000)
-#define VERSION             0x20230817
+#define FACTORY_DATA_LOC (0x80000 + 0x4000)
+#define VERSION          0x20230817
 
 const die_info_t *flash_get_die_info(void)
 {
@@ -197,7 +199,7 @@ const factory_calib_data_t *flash_get_factory_calib_data(void)
 {
     const factory_calib_data_t *p = (const factory_calib_data_t *)(FACTORY_DATA_LOC + 0x3000);
 
-    if(p->ft_version > VERSION)
+    if (p->ft_version > VERSION)
         return p;
     else
         return NULL;
@@ -210,25 +212,26 @@ const adc_calib_data_t *flash_get_adc_calib_data(void)
 
 void flash_read_uid(uint32_t uid[4])
 {
-    const die_info_t* die_info;
-    const factory_calib_data_t* factory_calib;
+    const die_info_t *die_info;
+    const factory_calib_data_t *factory_calib;
 
-    if(NULL == uid)
+    if (NULL == uid)
         return;
 
     EflashCacheBypass();
     die_info = flash_get_die_info();
     factory_calib = flash_get_factory_calib_data();
     uid[0] = die_info->lot_id[0];
-    uid[1] = die_info->lot_id[1] | (die_info->metal_id<<16) | (die_info->wafer_id<<24);
-    if(factory_calib)
+    uid[1] = die_info->lot_id[1] | (die_info->metal_id << 16) | (die_info->wafer_id << 24);
+    if (factory_calib)
     {
-        uid[2] = die_info->Die_x_local | (die_info->Die_y_local<<8) | ((*((uint32_t*)(&factory_calib->TRng_data[0]))) << 16);
-        uid[3] = *((uint32_t*)(&factory_calib->TRng_data[2]));
+        uid[2] = die_info->Die_x_local | (die_info->Die_y_local << 8) |
+                 ((*((uint32_t *)(&factory_calib->TRng_data[0]))) << 16);
+        uid[3] = *((uint32_t *)(&factory_calib->TRng_data[2]));
     }
     else
     {
-        uid[2] = die_info->Die_x_local | (die_info->Die_y_local<<8);
+        uid[2] = die_info->Die_x_local | (die_info->Die_y_local << 8);
         uid[3] = 0;
     }
     EflashCacheEna();
@@ -236,15 +239,15 @@ void flash_read_uid(uint32_t uid[4])
 
 int flash_read_uid45(uint8_t uid[6])
 {
-    const die_info_t* pDie_info;
+    const die_info_t *pDie_info;
 
-    if(NULL == uid)
+    if (NULL == uid)
         return -1;
 
     EflashCacheBypass();
     pDie_info = flash_get_die_info();
-    uint8_t *pLot = (uint8_t*)&pDie_info->lot_id[0];
-    uid[0] = pDie_info->wafer_id&0x1f;
+    uint8_t *pLot = (uint8_t *)&pDie_info->lot_id[0];
+    uid[0] = pDie_info->wafer_id & 0x1f;
     uid[1] = pLot[1];
     uid[2] = pLot[3];
     uid[3] = pLot[5];
@@ -260,32 +263,32 @@ int flash_read_uid45(uint8_t uid[6])
 #include "rom_tools.h"
 #include "peripheral_sysctrl.h"
 
-typedef void (* f_erase_sector)(uint32_t addr);
-typedef void (* f_void)(void);
-typedef void (* f_prog_page)(uint32_t addr, const uint8_t data[256], uint32_t len);
+typedef void (*f_erase_sector)(uint32_t addr);
+typedef void (*f_void)(void);
+typedef void (*f_prog_page)(uint32_t addr, const uint8_t data[256], uint32_t len);
 
-typedef int (* f_program_flash)(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size);
-typedef int (* f_write_flash)(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size);
-typedef int (* f_flash_do_update)(const int block_num, const fota_update_block_t *blocks, uint8_t *ram_buffer);
+typedef int (*f_program_flash)(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size);
+typedef int (*f_write_flash)(const uint32_t dest_addr, const uint8_t *buffer, uint32_t size);
+typedef int (*f_flash_do_update)(const int block_num, const fota_update_block_t *blocks, uint8_t *ram_buffer);
 
-#define ROM_program_flash               ((f_program_flash)0x00003b9b)
-#define ROM_write_flash                 ((f_write_flash)0x00003cff)
-#define ROM_flash_do_update             ((f_flash_do_update)0x00001d73)
+#define ROM_program_flash              ((f_program_flash)0x00003b9b)
+#define ROM_write_flash                ((f_write_flash)0x00003cff)
+#define ROM_flash_do_update            ((f_flash_do_update)0x00001d73)
 
 typedef void (*rom_void_void)(void);
-#define ROM_FlashWaitBusyDown           ((rom_void_void)(0x00000b6d))
-#define ROM_FlashDisableContinuousMode  ((rom_void_void)(0x000007c9))
-#define ROM_FlashEnableContinuousMode   ((rom_void_void)(0x0000080d))
-#define ROM_DCacheFlush                 ((rom_void_void)(0x00000651))
+#define ROM_FlashWaitBusyDown          ((rom_void_void)(0x00000b6d))
+#define ROM_FlashDisableContinuousMode ((rom_void_void)(0x000007c9))
+#define ROM_FlashEnableContinuousMode  ((rom_void_void)(0x0000080d))
+#define ROM_DCacheFlush                ((rom_void_void)(0x00000651))
 
 typedef void (*rom_prog_page)(uint32_t addr, const uint8_t *data, uint32_t len);
-#define ROM_ProgPage                    ((rom_prog_page)(0x00003cd7))
+#define ROM_ProgPage                   ((rom_prog_page)(0x00003cd7))
 
 typedef void (*rom_FlashSetStatusReg)(uint16_t data);
-#define ROM_FlashSetStatusReg           ((rom_FlashSetStatusReg)(0x00000b01))
+#define ROM_FlashSetStatusReg          ((rom_FlashSetStatusReg)(0x00000b01))
 
 typedef uint16_t (*rom_FlashGetStatusReg)(void);
-#define ROM_FlashGetStatusReg           ((rom_FlashGetStatusReg)(0x0000084d))
+#define ROM_FlashGetStatusReg          ((rom_FlashGetStatusReg)(0x0000084d))
 
 static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selection);
 
@@ -300,15 +303,16 @@ int program_flash(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
     return ROM_program_flash(dest_addr, buffer, size);
 }
 
-#define FLASH_PRE_OPS()                     \
-    uint32_t prim = __get_PRIMASK();        \
-    __disable_irq();                        \
+#define FLASH_PRE_OPS()                                                                                                \
+    uint32_t prim = __get_PRIMASK();                                                                                   \
+    __disable_irq();                                                                                                   \
     ROM_FlashDisableContinuousMode();
 
-#define FLASH_POST_OPS()                    \
-    ROM_DCacheFlush();                      \
-    ROM_FlashEnableContinuousMode();        \
-    if (!prim) __enable_irq()
+#define FLASH_POST_OPS()                                                                                               \
+    ROM_DCacheFlush();                                                                                                 \
+    ROM_FlashEnableContinuousMode();                                                                                   \
+    if (!prim)                                                                                                         \
+    __enable_irq()
 
 int write_flash0(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
 {
@@ -325,7 +329,8 @@ int write_flash0(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
         while (size > 0)
         {
             uint32_t block = next_page - dest_addr;
-            if (block >= size) block = size;
+            if (block >= size)
+                block = size;
 
             ROM_ProgPage(dest_addr, buffer, block);
 
@@ -342,7 +347,8 @@ int write_flash0(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
 int write_flash(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
 {
     int r = write_flash0(dest_addr, buffer, size);
-    if (r != 0) return r;
+    if (r != 0)
+        return r;
     r = memcmp((const void *)dest_addr, buffer, size) == 0 ? 0 : 2;
     return r;
 }
@@ -364,31 +370,24 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
 
 // this is compiled binary of the above `security_page_read`
 static const uint8_t prog_security_page_read[] = {
-    0x80, 0xB5, 0x82, 0xB0, 0x01, 0x90, 0x14, 0x21,
-    0xC4, 0xF2, 0x15, 0x01, 0x08, 0x68, 0x02, 0x22,
-    0x62, 0xF3, 0x52, 0x40, 0x08, 0x60, 0x04, 0x21,
-    0xC4, 0xF2, 0x15, 0x01, 0x08, 0x68, 0x04, 0x22,
-    0x62, 0xF3, 0x10, 0x20, 0x08, 0x60, 0x01, 0x98,
-    0x00, 0x02, 0x48, 0x30, 0x00, 0x21, 0xC4, 0xF2,
-    0x15, 0x01, 0x08, 0x60, 0x40, 0xF6, 0x6D, 0x30,
-    0x80, 0x47, 0x10, 0x20, 0xC4, 0xF2, 0x15, 0x00,
-    0x00, 0x68, 0x02, 0xB0, 0x80, 0xBD, 0x00, 0x00
-};
+    0x80, 0xB5, 0x82, 0xB0, 0x01, 0x90, 0x14, 0x21, 0xC4, 0xF2, 0x15, 0x01, 0x08, 0x68, 0x02, 0x22, 0x62, 0xF3,
+    0x52, 0x40, 0x08, 0x60, 0x04, 0x21, 0xC4, 0xF2, 0x15, 0x01, 0x08, 0x68, 0x04, 0x22, 0x62, 0xF3, 0x10, 0x20,
+    0x08, 0x60, 0x01, 0x98, 0x00, 0x02, 0x48, 0x30, 0x00, 0x21, 0xC4, 0xF2, 0x15, 0x01, 0x08, 0x60, 0x40, 0xF6,
+    0x6D, 0x30, 0x80, 0x47, 0x10, 0x20, 0xC4, 0xF2, 0x15, 0x00, 0x00, 0x68, 0x02, 0xB0, 0x80, 0xBD, 0x00, 0x00};
 
 
 #if ((defined __ARMCC_VERSION) && (__ARMCC_VERSION < 6000000))
 asm static uint32_t security_page_read(uint32_t addr, uint32_t prog)
 {
-    ADD r1, r1, #1
-    BX  r1
+    ADD r1, r1, #1 BX r1
 }
 #else
 __attribute__((naked)) static uint32_t security_page_read(uint32_t addr, uint32_t prog)
 {
-    #if defined(__GNUC__) && !defined(__ARMCC_VERSION)
+#if defined(__GNUC__) && !defined(__ARMCC_VERSION)
     (void)addr;
     (void)prog;
-    #endif
+#endif
     __asm("ADD r1, r1, #1");
     __asm("BX  r1");
 }
@@ -426,27 +425,27 @@ uint32_t read_flash_security(uint32_t addr)
     }
 }
 
-#define FACTORY_DATA_LOC    (0x02000000 + 0x1000)
+#define FACTORY_DATA_LOC (0x02000000 + 0x1000)
 
-#define MAGIC_0             0x494e4743
-#define MAGIC_1             0x48495053
+#define MAGIC_0 0x494e4743
+#define MAGIC_1 0x48495053
 
-#pragma pack (push, 1)
+#pragma pack(push, 1)
 typedef struct
 {
     die_info_t die_info;
     factory_calib_data_t calib;
 } factory_data_t;
-#pragma pack (pop)
+#pragma pack(pop)
 
-#define EXTRA_DATA_LEN      320
-#define FT_CHECK_LEN        (((sizeof(factory_data_t) + EXTRA_DATA_LEN) + 3) & ~4)
-#define FT_CEHCKSUM_OFFSET  FT_CHECK_LEN
+#define EXTRA_DATA_LEN     320
+#define FT_CHECK_LEN       (((sizeof(factory_data_t) + EXTRA_DATA_LEN) + 3) & ~4)
+#define FT_CEHCKSUM_OFFSET FT_CHECK_LEN
 
-static uint32_t calc_checksum_32(const uint32_t* data, uint32_t length)
+static uint32_t calc_checksum_32(const uint32_t *data, uint32_t length)
 {
     uint32_t sum = 0;
-    while(length--)
+    while (length--)
         sum += *data++;
     return sum;
 }
@@ -458,7 +457,7 @@ static uint32_t calc_ft_sum()
 
 static uint32_t get_ft_sum()
 {
-    return *(uint32_t*)(FACTORY_DATA_LOC + FT_CEHCKSUM_OFFSET);
+    return *(uint32_t *)(FACTORY_DATA_LOC + FT_CEHCKSUM_OFFSET);
 }
 
 static void write_ft_sum()
@@ -517,11 +516,14 @@ static int check_security_data(uint32_t dst, uintptr_t src, uint32_t word_len)
 
 int flash_prepare_factory_data(void)
 {
-    if (is_data_ready()) return 0;
+    if (is_data_ready())
+        return 0;
     uint32_t t = read_flash_security(0x1000);
-    if (t != MAGIC_0) return 1;
+    if (t != MAGIC_0)
+        return 1;
     t = read_flash_security(0x1004);
-    if (t != MAGIC_1) return 2;
+    if (t != MAGIC_1)
+        return 2;
 
     uint8_t region;
     uint8_t reverse_selection;
@@ -529,20 +531,14 @@ int flash_prepare_factory_data(void)
     flash_enable_write_protection(FLASH_REGION_NONE, 0);
 
     erase_flash_sector(FACTORY_DATA_LOC);
-    copy_security_data(FACTORY_DATA_LOC,
-        0x1000, sizeof(die_info_t) / 4);
-    copy_security_data(FACTORY_DATA_LOC + sizeof(die_info_t),
-        0x1100, sizeof(factory_calib_data_t) / 4);
-    copy_security_data(FACTORY_DATA_LOC + sizeof(factory_data_t),
-        0x2000, EXTRA_DATA_LEN / 4);
-    if(check_security_data(FACTORY_DATA_LOC,
-        0x1000, sizeof(die_info_t) / 4))
+    copy_security_data(FACTORY_DATA_LOC, 0x1000, sizeof(die_info_t) / 4);
+    copy_security_data(FACTORY_DATA_LOC + sizeof(die_info_t), 0x1100, sizeof(factory_calib_data_t) / 4);
+    copy_security_data(FACTORY_DATA_LOC + sizeof(factory_data_t), 0x2000, EXTRA_DATA_LEN / 4);
+    if (check_security_data(FACTORY_DATA_LOC, 0x1000, sizeof(die_info_t) / 4))
         goto check_failed;
-    if(check_security_data(FACTORY_DATA_LOC + sizeof(die_info_t),
-        0x1100, sizeof(factory_calib_data_t) / 4))
+    if (check_security_data(FACTORY_DATA_LOC + sizeof(die_info_t), 0x1100, sizeof(factory_calib_data_t) / 4))
         goto check_failed;
-    if(check_security_data(FACTORY_DATA_LOC + sizeof(factory_data_t),
-        0x2000, EXTRA_DATA_LEN / 4))
+    if (check_security_data(FACTORY_DATA_LOC + sizeof(factory_data_t), 0x2000, EXTRA_DATA_LEN / 4))
         goto check_failed;
     write_ft_sum();
 
@@ -581,8 +577,8 @@ const void *flash_get_adc_calib_data(void)
         return NULL;
 }
 
-typedef void (* rom_FlashRUID)(uint32_t *UID);
-#define ROM_FlashRUID  ((rom_FlashRUID) (0x00000a41))
+typedef void (*rom_FlashRUID)(uint32_t *UID);
+#define ROM_FlashRUID      ((rom_FlashRUID)(0x00000a41))
 
 void flash_read_uid(uint32_t uid[4])
 {
@@ -597,9 +593,9 @@ void flash_read_uid(uint32_t uid[4])
 #include "peripheral_sysctrl.h"
 #include "eflash_security.h"
 
-typedef void (* f_void)(void);
-typedef void (* f_prog_page)(uint32_t addr, const uint8_t data[256], uint32_t len);
-typedef int (* f_flash_do_update)(const int block_num, const fota_update_block_t *blocks, uint8_t *ram_buffer);
+typedef void (*f_void)(void);
+typedef void (*f_prog_page)(uint32_t addr, const uint8_t data[256], uint32_t len);
+typedef int (*f_flash_do_update)(const int block_num, const fota_update_block_t *blocks, uint8_t *ram_buffer);
 
 typedef void (*rom_void_void)(void);
 typedef void (*rom_FlashSectorErase)(uint8_t info, uint32_t addr);
@@ -608,44 +604,49 @@ typedef void (*rom_FlashWriteStatusReg)(uint16_t data);
 typedef uint8_t (*rom_FlashReadReg)(uint8_t cmd);
 typedef uint32_t (*rom_FlashSecurityPageRead)(uint32_t addr);
 
-#define ROM_flash_do_update                 ((f_flash_do_update)0x00008eb9)
+#define ROM_flash_do_update ((f_flash_do_update)0x00008eb9)
 
-#define ROM_FlashSectorErase                ((rom_FlashSectorErase)0x000007a1)
-#define ROM_FlashDisableContinuousMode      ((rom_void_void)0x0000072d)
-#define ROM_FlashEnableContinuousMode       ((rom_void_void)0x0000077d)
-#define ROM_FlashPageProgram                ((rom_FlashPageProgram)0x000007c9)
+#define ROM_FlashSectorErase           ((rom_FlashSectorErase)0x000007a1)
+#define ROM_FlashDisableContinuousMode ((rom_void_void)0x0000072d)
+#define ROM_FlashEnableContinuousMode  ((rom_void_void)0x0000077d)
+#define ROM_FlashPageProgram           ((rom_FlashPageProgram)0x000007c9)
 
-#define IS_CONTINUOUS_MODE()                ((io_read(0x40150004) & 0x1000000ul) != 0)
+#define IS_CONTINUOUS_MODE() ((io_read(0x40150004) & 0x1000000ul) != 0)
 
-#define ROM_FlashReadReg                    ((rom_FlashReadReg)(0x000009dd))
-#define ROM_FlashWriteStatusReg             ((rom_FlashWriteStatusReg)(0x00000b71))
-#define read_flash_security                 ((rom_FlashSecurityPageRead)(0x00000a4d))
+#define ROM_FlashReadReg        ((rom_FlashReadReg)(0x000009dd))
+#define ROM_FlashWriteStatusReg ((rom_FlashWriteStatusReg)(0x00000b71))
+#define read_flash_security     ((rom_FlashSecurityPageRead)(0x00000a4d))
 
-#define FLASH_PROGRAM_CHUNK_SIZE            32u
+#define FLASH_PROGRAM_CHUNK_SIZE 32u
 
-#define FLASH_PRE_OPS()                         \
-    uint32_t prim;              \
-    uint8_t mode = 0; \
-    prim =  __get_PRIMASK();  \
-    __disable_irq();                            \
-    if (IS_CONTINUOUS_MODE()) {                 \
-        mode = 1;                               \
-        ROM_FlashDisableContinuousMode();       \
+#define FLASH_PRE_OPS()                                                                                                \
+    uint32_t prim;                                                                                                     \
+    uint8_t mode = 0;                                                                                                  \
+    prim = __get_PRIMASK();                                                                                            \
+    __disable_irq();                                                                                                   \
+    if (IS_CONTINUOUS_MODE())                                                                                          \
+    {                                                                                                                  \
+        mode = 1;                                                                                                      \
+        ROM_FlashDisableContinuousMode();                                                                              \
     }
 
-#define FLASH_POST_OPS()                    \
-    if (mode) ROM_FlashEnableContinuousMode(); \
-    if (!prim) __enable_irq()
+#define FLASH_POST_OPS()                                                                                               \
+    if (mode)                                                                                                          \
+        ROM_FlashEnableContinuousMode();                                                                               \
+    if (!prim)                                                                                                         \
+    __enable_irq()
 
 static inline void flash_program_write(uint32_t dest_addr, const uint8_t *buffer, uint32_t len)
 {
     uint32_t chunk;
 #if (FLASH_PROGRAM_WITH_DMA == 1)
-    uint32_t reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18))&(0x1<<31);
+    uint32_t reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)) & (0x1 << 31);
 
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1<<31);
+    if (reg_state)
+        *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18) &= ~(0x1 << 31);
     ROM_FlashPageProgram(0x02, dest_addr, buffer, len);
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1<<31);
+    if (reg_state)
+        *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18) |= (0x1 << 31);
 #else
     while (len > 0u)
     {
@@ -678,7 +679,8 @@ int erase_flash_page(const uint32_t addr)
 
 int program_flash(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
 {
-    if (dest_addr & (EFLASH_SECTOR_SIZE - 1)) return -1;
+    if (dest_addr & (EFLASH_SECTOR_SIZE - 1))
+        return -1;
 
     FLASH_PRE_OPS();
     while (size > 0)
@@ -719,7 +721,8 @@ int write_flash(uint32_t dest_addr, const uint8_t *buffer, uint32_t size)
     while (size > 0)
     {
         uint32_t block = next_page - dest_addr;
-        if (block >= size) block = size;
+        if (block >= size)
+            block = size;
 
         flash_program_write(dest_addr, buffer, block);
         dest_addr += block;
@@ -741,7 +744,7 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
         ROM_FlashEnableContinuousMode();
     }
 
-    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1ul<<31);
+    *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18) &= ~(0x1ul << 31);
 
     int r = ROM_flash_do_update(block_num, blocks, page_buffer);
     SYSCTRL_ICacheFlush();
@@ -752,15 +755,21 @@ int flash_do_update(const int block_num, const fota_update_block_t *blocks, uint
     return r;
 }
 
-static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
+static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen)
+{
     uint16_t crc = 0xFFFF;
     int i;
-    while (usDataLen--) {
+    while (usDataLen--)
+    {
         crc ^= *puchMsg++;
-        for (i = 0; i < 8; i++) {
-            if (crc & 0x0001) {
+        for (i = 0; i < 8; i++)
+        {
+            if (crc & 0x0001)
+            {
                 crc = (crc >> 1) ^ 0xA001;
-            } else {
+            }
+            else
+            {
                 crc >>= 1;
             }
         }
@@ -768,16 +777,16 @@ static uint16_t crc16(uint8_t *puchMsg, uint16_t usDataLen) {
     return ((crc & 0xFF) << 8) | (crc >> 8);
 }
 
-#define FACTORY_DATA_LOC    (0x02000000 + 0x1000)
-#define FACTORY_DIE_INFO_SRC_ADDR      (0x00000000u)
-#define FACTORY_CALIB_SRC_ADDR         (0x00000100u)
-#define FACTORY_DATA_DIE_INFO          (FACTORY_DATA_LOC)
-#define FACTORY_DATA_CALIB             (FACTORY_DATA_LOC + 0x100)
-#define FACTORY_DATA_CLC               (FACTORY_DATA_LOC + 0x200)
-#define ADC_CAL_CHANNEL_NUM            9
+#define FACTORY_DATA_LOC          (0x02000000 + 0x1000)
+#define FACTORY_DIE_INFO_SRC_ADDR (0x00000000u)
+#define FACTORY_CALIB_SRC_ADDR    (0x00000100u)
+#define FACTORY_DATA_DIE_INFO     (FACTORY_DATA_LOC)
+#define FACTORY_DATA_CALIB        (FACTORY_DATA_LOC + 0x100)
+#define FACTORY_DATA_CLC          (FACTORY_DATA_LOC + 0x200)
+#define ADC_CAL_CHANNEL_NUM       9
 
 
-static uint16_t calc_factory_info_crc16(const die_info_t *info,  uint32_t len)
+static uint16_t calc_factory_info_crc16(const die_info_t *info, uint32_t len)
 {
     return crc16((uint8_t *)info, len - 4);
 }
@@ -812,8 +821,7 @@ static int factory_data_ready(void)
 {
     const factory_clc_data_t *factory = (const factory_clc_data_t *)FACTORY_DATA_CLC;
 
-    if ((factory->magic_0 != FACTORY_DATA_MAGIC_0) ||
-        (factory->magic_1 != FACTORY_DATA_MAGIC_1))
+    if ((factory->magic_0 != FACTORY_DATA_MAGIC_0) || (factory->magic_1 != FACTORY_DATA_MAGIC_1))
         return 0;
 
     return 1;
@@ -823,18 +831,13 @@ const factory_clc_data_t *flash_get_factory_clc_data(void)
 {
     const factory_clc_data_t *factory = (const factory_clc_data_t *)FACTORY_DATA_CLC;
 
-    if ((factory->magic_0 != FACTORY_DATA_MAGIC_0) ||
-        (factory->magic_1 != FACTORY_DATA_MAGIC_1))
+    if ((factory->magic_0 != FACTORY_DATA_MAGIC_0) || (factory->magic_1 != FACTORY_DATA_MAGIC_1))
         return 0;
 
     return (const factory_clc_data_t *)FACTORY_DATA_CLC;
 }
 
-static void factory_set_linear_calib(adc_linear_calib_t *cal,
-                                     uint16_t raw0,
-                                     float phy0,
-                                     uint16_t raw1,
-                                     float phy1)
+static void factory_set_linear_calib(adc_linear_calib_t *cal, uint16_t raw0, float phy0, uint16_t raw1, float phy1)
 {
     if ((cal == NULL) || (raw0 == raw1))
         return;
@@ -843,10 +846,7 @@ static void factory_set_linear_calib(adc_linear_calib_t *cal,
     cal->b = phy0 - cal->k * (float)raw0;
 }
 
-static void factory_set_vbat_calib(adc_vbat_calib_t *cal,
-                                   uint16_t raw_vbat33,
-                                   float vbat33,
-                                   uint16_t raw_vbat25,
+static void factory_set_vbat_calib(adc_vbat_calib_t *cal, uint16_t raw_vbat33, float vbat33, uint16_t raw_vbat25,
                                    float vbat25, float vref)
 {
     float x0 = 1.01f / (float)raw_vbat33;
@@ -875,18 +875,12 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
 
     for (i = 0; i < ADC_CAL_CHANNEL_NUM; ++i)
     {
-        factory_set_linear_calib(&dst->ch0_8_int_ref[i],
-                                    src->calib_adc.int_vbat33_ain_ch0_8[i][0],
-                                    682.6667f,
-                                    src->calib_adc.int_vbat33_ain_ch0_8[i][1],
-                                    2275.5556f);
-        factory_set_linear_calib(&dst->ch0_8_vbat_ref[i],
-                                    src->calib_adc.vbat33_flt_ain_ch0_8[i][0],
-                                    620.6060f,
-                                    src->calib_adc.vbat33_flt_ain_ch0_8[i][1],
-                                    3351.2727f);
+        factory_set_linear_calib(&dst->ch0_8_int_ref[i], src->calib_adc.int_vbat33_ain_ch0_8[i][0], 682.6667f,
+                                 src->calib_adc.int_vbat33_ain_ch0_8[i][1], 2275.5556f);
+        factory_set_linear_calib(&dst->ch0_8_vbat_ref[i], src->calib_adc.vbat33_flt_ain_ch0_8[i][0], 620.6060f,
+                                 src->calib_adc.vbat33_flt_ain_ch0_8[i][1], 3351.2727f);
     }
-    if(src->calib_adc.version == 0x10)
+    if (src->calib_adc.version == 0x10)
     {
         for (i = 0; i < 8; i++)
         {
@@ -896,10 +890,9 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
             }
             else
                 vref = 1.01f;
-
         }
     }
-    else if(src->calib_adc.version == 0x11)
+    else if (src->calib_adc.version == 0x11)
     {
         for (i = 0; i < 16; i++)
         {
@@ -914,11 +907,8 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
     else
         vref = 1.01f;
 
-    factory_set_vbat_calib(&dst->ch9_vbat,
-                           src->calib_adc.vbat33_flt_int_ch9_11[0],
-                           3.3f,
-                           src->calib_adc.vbat25_flt_int_ch9_11[0],
-                           2.5f, vref);
+    factory_set_vbat_calib(&dst->ch9_vbat, src->calib_adc.vbat33_flt_int_ch9_11[0], 3.3f,
+                           src->calib_adc.vbat25_flt_int_ch9_11[0], 2.5f, vref);
 }
 
 int flash_prepare_factory_data(void)
@@ -933,14 +923,14 @@ int flash_prepare_factory_data(void)
     if (factory_data_ready())
         return 0;
 
-    reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18))&(0x1ul<<31);
+    reg_state = (*(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)) & (0x1ul << 31);
 
     flash_read_protection_status(&region, &reverse_selection);
     flash_enable_write_protection(FLASH_REGION_NONE, 0);
 
     FLASH_PRE_OPS();
 
-    if(read_flash_security(FACTORY_DIE_INFO_SRC_ADDR) == 0xfffffffful)
+    if (read_flash_security(FACTORY_DIE_INFO_SRC_ADDR) == 0xfffffffful)
     {
         // no ft data;
         FLASH_POST_OPS();
@@ -949,17 +939,13 @@ int flash_prepare_factory_data(void)
     }
     FLASH_POST_OPS();
 
-    copy_security_bytes((uint8_t *)&die_info,
-                        FACTORY_DIE_INFO_SRC_ADDR,
-                        sizeof(die_info));
-    copy_security_bytes((uint8_t *)&calib,
-                        FACTORY_CALIB_SRC_ADDR,
-                        sizeof(calib));
+    copy_security_bytes((uint8_t *)&die_info, FACTORY_DIE_INFO_SRC_ADDR, sizeof(die_info));
+    copy_security_bytes((uint8_t *)&calib, FACTORY_CALIB_SRC_ADDR, sizeof(calib));
 
     uint16_t crc = calc_factory_info_crc16(&die_info, sizeof(die_info));
     if (crc != die_info.info_crc16)
         goto check_failed;
-    if(die_info.version == 0x100)
+    if (die_info.version == 0x100)
         crc = calc_factory_calib_crc16(&calib, sizeof(calib) - sizeof(factory_calib_bor_t));
     else
         crc = calc_factory_calib_crc16(&calib, sizeof(calib));
@@ -967,46 +953,35 @@ int flash_prepare_factory_data(void)
         goto check_failed;
     erase_flash_sector(FACTORY_DATA_LOC);
 
-    if (write_flash(FACTORY_DATA_LOC,
-                    (const uint8_t *)&die_info,
-                    sizeof(die_info)) != 0)
+    if (write_flash(FACTORY_DATA_LOC, (const uint8_t *)&die_info, sizeof(die_info)) != 0)
         goto check_failed;
-    if (write_flash(FACTORY_DATA_CALIB,
-                    (const uint8_t *)&calib,
-                    sizeof(calib)) != 0)
+    if (write_flash(FACTORY_DATA_CALIB, (const uint8_t *)&calib, sizeof(calib)) != 0)
         goto check_failed;
 
-    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_DIE_INFO),
-               (const void *)&die_info,
-               sizeof(die_info)) != 0)
+    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_DIE_INFO), (const void *)&die_info, sizeof(die_info)) != 0)
         goto check_failed;
-    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_CALIB),
-               (const void *)&calib,
-               sizeof(calib)) != 0)
+    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_CALIB), (const void *)&calib, sizeof(calib)) != 0)
         goto check_failed;
 
     flash_build_factory_clc_data(&calib, &generated);
 
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)&=~(0x1ul<<31);
-    if (write_flash(FACTORY_DATA_CLC,
-                    (const uint8_t *)&generated,
-                    sizeof(generated) - 8) != 0)
+    if (reg_state)
+        *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18) &= ~(0x1ul << 31);
+    if (write_flash(FACTORY_DATA_CLC, (const uint8_t *)&generated, sizeof(generated) - 8) != 0)
         goto check_failed;
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1ul<<31);
-    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_CLC),
-               (const void *)&generated,
-               sizeof(generated) - 8) != 0)
+    if (reg_state)
+        *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18) |= (0x1ul << 31);
+    if (memcmp((const void *)((const uint8_t *)FACTORY_DATA_CLC), (const void *)&generated, sizeof(generated) - 8) != 0)
         goto check_failed;
-    if (write_flash(FACTORY_DATA_CLC + sizeof(generated) - 8,
-                    (const uint8_t *)&generated.magic_0,
-                    8) != 0)
+    if (write_flash(FACTORY_DATA_CLC + sizeof(generated) - 8, (const uint8_t *)&generated.magic_0, 8) != 0)
         goto check_failed;
 
     flash_enable_write_protection((flash_region_t)region, reverse_selection);
     return 0;
 
 check_failed:
-    if(reg_state) *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18)|=(0x1ul<<31);
+    if (reg_state)
+        *(volatile uint32_t *)(AON1_CTRL_BASE + 0x18) |= (0x1ul << 31);
     erase_flash_sector(FACTORY_DATA_LOC);
     flash_enable_write_protection((flash_region_t)region, reverse_selection);
 
@@ -1029,8 +1004,8 @@ const factory_calib_data_t *flash_get_factory_calib_data(void)
     return NULL;
 }
 
-typedef void (* rom_FlashRUID)(uint32_t *UID);
-#define ROM_FlashRUID  ((rom_FlashRUID) (0x00000989))
+typedef void (*rom_FlashRUID)(uint32_t *UID);
+#define ROM_FlashRUID             ((rom_FlashRUID)(0x00000989))
 
 void flash_read_uid(uint32_t uid[4])
 {
@@ -1151,7 +1126,7 @@ void flash_enable_write_protection(flash_region_t region, uint8_t reverse_select
         status &= ~((1ul << 14) | (0x1ful << 2));
         status |= (uint16_t)reverse_selection << 14 | ((uint16_t)region << 2);
         if (old_status != status)
-           ROM_FlashSetStatusReg(status);
+            ROM_FlashSetStatusReg(status);
     }
     FLASH_POST_OPS();
 }
@@ -1162,7 +1137,7 @@ static void flash_read_protection_status(uint8_t *region, uint8_t *reverse_selec
 {
     FLASH_PRE_OPS();
     {
-        uint16_t status = ROM_FlashReadReg(0x05) | (ROM_FlashReadReg(0x35)<<8);
+        uint16_t status = ROM_FlashReadReg(0x05) | (ROM_FlashReadReg(0x35) << 8);
         *reverse_selection = ((status >> 14) & 1ul);
         *region = (0x1ful & (status >> 2));
     }
@@ -1173,7 +1148,7 @@ void flash_enable_write_protection(flash_region_t region, uint8_t reverse_select
 {
     FLASH_PRE_OPS();
     {
-        uint16_t status = ROM_FlashReadReg(0x05) | (ROM_FlashReadReg(0x35)<<8);
+        uint16_t status = ROM_FlashReadReg(0x05) | (ROM_FlashReadReg(0x35) << 8);
         uint16_t old_status = status;
         status &= ~((1ul << 14) | (0x1ful << 2));
         status |= (uint16_t)reverse_selection << 14 | ((uint16_t)region << 2);

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -377,11 +377,13 @@ static const uint8_t prog_security_page_read[] = {
 
 
 #if ((defined __ARMCC_VERSION) && (__ARMCC_VERSION < 6000000))
+// clang-format off
 asm static uint32_t security_page_read(uint32_t addr, uint32_t prog)
 {
-    ADD r1, r1, #1 
+    ADD r1, r1, #1
     BX r1
 }
+// clang-format on
 #else
 __attribute__((naked)) static uint32_t security_page_read(uint32_t addr, uint32_t prog)
 {

--- a/src/BSP/eflash.c
+++ b/src/BSP/eflash.c
@@ -379,7 +379,8 @@ static const uint8_t prog_security_page_read[] = {
 #if ((defined __ARMCC_VERSION) && (__ARMCC_VERSION < 6000000))
 asm static uint32_t security_page_read(uint32_t addr, uint32_t prog)
 {
-    ADD r1, r1, #1 BX r1
+    ADD r1, r1, #1 
+    BX r1
 }
 #else
 __attribute__((naked)) static uint32_t security_page_read(uint32_t addr, uint32_t prog)

--- a/src/BSP/eflash.h
+++ b/src/BSP/eflash.h
@@ -621,6 +621,11 @@ void flash_build_factory_clc_data(const factory_calib_data_t *src, factory_clc_d
 /**
  * @brief Set Vcore value from FT data;
  *
+ * @note
+ * If there is no ft data, the interface will set the default voltage value.
+ * Vaon: 1.05V
+ * Vcore: 1.18V
+ * VDCDC: 1.33V
  */
 int Vcore_calib(void);
 

--- a/src/FWlib/peripheral_adc.c
+++ b/src/FWlib/peripheral_adc.c
@@ -961,39 +961,38 @@ void ADC_SetVref(SADC_Vref vref)
     APB_SADC->sadc_cfg[0] &= ~(0x20000088);
     switch (vref)
     {
-        case VREF_IN_MODE:
-            ADC_RegClr(SADC_CFG_0, 29, 1);
-            ADC_RegClr(SADC_CFG_0, 7, 1);
-            ADC_RegWr(SADC_CFG_0, 1, 3);
+    case VREF_IN_MODE:
+        ADC_RegClr(SADC_CFG_0, 29, 1);
+        ADC_RegClr(SADC_CFG_0, 7, 1);
+        ADC_RegWr(SADC_CFG_0, 1, 3);
         break;
-        case VREF_OUT_MODE:
-            ADC_RegClr(SADC_CFG_0, 3, 1);
-            ADC_RegClr(SADC_CFG_0, 7, 1);
-            ADC_RegWr(SADC_CFG_0, 1, 29);
+    case VREF_OUT_MODE:
+        ADC_RegClr(SADC_CFG_0, 3, 1);
+        ADC_RegClr(SADC_CFG_0, 7, 1);
+        ADC_RegWr(SADC_CFG_0, 1, 29);
         break;
-        case VREF_LDO33_MODE:
-            ADC_RegClr(SADC_CFG_0, 29, 1);
-            ADC_RegClr(SADC_CFG_0, 3, 1);
-            ADC_RegWr(SADC_CFG_0, 1, 7);
+    case VREF_LDO33_MODE:
+        ADC_RegClr(SADC_CFG_0, 29, 1);
+        ADC_RegClr(SADC_CFG_0, 3, 1);
+        ADC_RegWr(SADC_CFG_0, 1, 7);
         break;
-        default:
+    default:
         break;
     }
 }
 
-void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode,
-                 SADC_channelId ch,
-                 uint8_t enNum,
-                 uint8_t dmaEnNum,
-                 uint32_t loopDelay)
+void ADC_ConvCfg(SADC_adcCtrlMode ctrlMode, SADC_channelId ch, uint8_t enNum, uint8_t dmaEnNum, uint32_t loopDelay)
 {
     ADC_SetAdcMode(CONVERSION_MODE);
     ADC_SetAdcCtrlMode(ctrlMode);
     ADC_EnableChannel(ch, 1);
-    if (enNum) {
+    if (enNum)
+    {
         ADC_IntEnable(1);
         ADC_SetIntTrig(enNum);
-    } else if (dmaEnNum) {
+    }
+    else if (dmaEnNum)
+    {
         ADC_DmaEnable(1);
         ADC_SetDmaTrig(dmaEnNum);
     }
@@ -1024,18 +1023,18 @@ static float ADC_ApplyLinearCalib(const adc_linear_calib_t *cal, uint16_t raw)
 static float ADC_ApplyVBatCalib(const adc_vbat_calib_t *cal, uint16_t raw)
 {
     int i;
-    uint32_t temp = raw *1000;
-    const factory_calib_data_t * calib_data = flash_get_factory_calib_data();
+    uint32_t temp = raw * 1000;
+    const factory_calib_data_t *calib_data = flash_get_factory_calib_data();
     if ((cal == 0) || (raw == 0U))
         return 0.0f;
     for (i = 0; i < 16; i++)
     {
         if (calib_data->calib_pmu.vcore[i] > 1170)
         {
-            return cal->k*((float)calib_data->calib_pmu.vcore[i] / (float)temp)  + cal->b;
+            return cal->k * ((float)calib_data->calib_pmu.vcore[i] / (float)temp) + cal->b;
         }
     }
-    return cal->k*(1.171f / (float)raw)  + cal->b;
+    return cal->k * (1.171f / (float)raw) + cal->b;
 }
 
 static const factory_clc_data_t *ADC_GetCalibrationData(void)
@@ -1045,8 +1044,7 @@ static const factory_clc_data_t *ADC_GetCalibrationData(void)
     if (stored == 0)
         return 0;
 
-    if ((stored->magic_0 != FACTORY_DATA_MAGIC_0) ||
-        (stored->magic_1 != FACTORY_DATA_MAGIC_1) ||
+    if ((stored->magic_0 != FACTORY_DATA_MAGIC_0) || (stored->magic_1 != FACTORY_DATA_MAGIC_1) ||
         (stored->version != FACTORY_CLC_DATA_VERSION))
         return 0;
 
@@ -1060,13 +1058,24 @@ float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw)
 
     cal = ADC_GetCalibrationData();
     if (cal == NULL)
-        return (float)raw;
+    {
+        if (ch <= ADC_CH_1)
+        {
+            return ((float)raw / 4096) * 2 * 3.3f;
+        }
+        else if (ch <= ADC_CH_8)
+        {
+            return ((float)raw / 4096) * 3.3f;
+        }
+        else if (ch == ADC_CH_9)
+        {
+            return (4096 / (float)raw) * 1.20f;
+        }
+    }
 
     if (ch <= ADC_CH_8)
     {
-        linear = (ADC_GetCurrentVref() == VREF_IN_MODE) ?
-                 &cal->ch0_8_int_ref[ch] :
-                 &cal->ch0_8_vbat_ref[ch];
+        linear = (ADC_GetCurrentVref() == VREF_IN_MODE) ? &cal->ch0_8_int_ref[ch] : &cal->ch0_8_vbat_ref[ch];
         return ADC_ApplyLinearCalib(linear, raw);
     }
 
@@ -1088,12 +1097,21 @@ float ADC_GetCalibValueVRefVBat(SADC_channelId ch, uint16_t raw, float vbat)
 
     cal = ADC_GetCalibrationData();
     if (cal == NULL)
-        return (float)raw;
+    {
+        if (ch <= ADC_CH_1)
+        {
+            return ((float)raw / 4096) * 2 * 3.3f;
+        }
+        else if (ch <= ADC_CH_8)
+        {
+            return ((float)raw / 4096) * 3.3f;
+        }
+    }
 
     if (ch <= ADC_CH_8)
     {
         memcpy(&linear_data, &cal->ch0_8_vbat_ref[ch], sizeof(adc_linear_calib_t));
-        linear_data.k = linear_data.k*(vbat/3.3f);
+        linear_data.k = linear_data.k * (vbat / 3.3f);
         return ADC_ApplyLinearCalib(&linear_data, raw);
     }
 

--- a/src/FWlib/peripheral_adc.h
+++ b/src/FWlib/peripheral_adc.h
@@ -730,7 +730,7 @@ void ADC_HardwareCalibration(void);
  * When using VBAT as the standard VREF, if VBAT is not 3.3 V,
  * Use 'ADC_GetCalibValueVRefVBat'
  *
- * For CH0-CH8 the return value. rand in 0-4096.
+ * For CH0-CH8 the return value. Vio voltage in 0-3.3V.
  * For CH9 under VBAT reference the return value is VBAT voltage in V.
  * For CH10-CH11 the raw code is returned as float.
  *
@@ -745,7 +745,7 @@ float ADC_GetCalibratedValue(SADC_channelId ch, uint16_t raw);
  * When using VBAT as the standard VREF, if VBAT is not 3.3 V,
  * you must use this interface to obtain the calibrated value.
  *
- * Only CH0-CH8 the return value. rand in 0-4096.
+ * Only CH0-CH8 the return value. Vio voltage in 0-VBAT V.
  *
  * @param[in] ch                ADC channel
  * @param[in] raw               raw ADC code

--- a/src/FWlib/peripheral_sysctrl.c
+++ b/src/FWlib/peripheral_sysctrl.c
@@ -2028,10 +2028,10 @@ uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
 {
     static volatile uint32_t pcap[2];
     uint32_t diff;
-    
+
     uint32_t freq;
     volatile DMA_Descriptor descriptor __attribute__((aligned(8)));
-    
+
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) &= ~(0xfful<<24);
     *(volatile uint32_t *)(AON1_CTRL_BASE + 0x3C) |= (clc&0xff)<<24;
     APB_PWM->Channels[0].Ctrl0 = (0x6<<7)|(0x1<<21)|(0x1<<20);
@@ -2043,7 +2043,7 @@ uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
     descriptor.DstAddr = (uint32_t)&pcap[1];
     descriptor.TranSize = 1000*2-1;
     descriptor.Next = 0;
-    
+
     APB_DMA->Channels[0].Descriptor.Ctrl = 0x0|(0x8<<8)|(0x2<<14)|(0x0<<16)|(0x1<<17)|(0x2<<18)|(0x2<<21)|(0x1<<24) ;
     APB_DMA->Channels[0].Descriptor.SrcAddr = (uint32_t)(&APB_PWM->PCAPChannels[0].Ctrl1);
     APB_DMA->Channels[0].Descriptor.DstAddr = (uint32_t)pcap;
@@ -2052,7 +2052,7 @@ uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
     __DSB();
     APB_DMA->Channels[0].Descriptor.Ctrl |= 0x1;
     APB_PWM->Channels[0].Ctrl0 |= 0x1<<6;
-    
+
     while (!(APB_DMA->IntStatus & (0x1<<16)));
     APB_DMA->IntStatus = 0xffffffff;
     __DSB();
@@ -2060,7 +2060,7 @@ uint32_t SYSCTRL_RC2MCalib(uint32_t clc)
 
     diff = pcap[1] - pcap[0];
     freq = (1000UL * 24000UL) / diff;
-    
+
     SYSCTRL_ResetBlock(SYSCTRL_ITEM_APB_PWM);
     SYSCTRL_ReleaseBlock(SYSCTRL_ITEM_APB_PWM);
     return (uint32_t)(freq*1000);
@@ -2076,13 +2076,13 @@ uint32_t SYSCTRL_RC2MTune(uint32_t freq)
     uint32_t max;
 
     uint32_t Freq;
-    
+
     uint8_t enabled = io_read(AON1_CTRL_BASE + 0x28) & 1;
     SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_DMA);
     SYSCTRL_ClearClkGate(SYSCTRL_ITEM_APB_PWM);
     set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 0);
     set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 1, 3);
-    
+
     APB_SYSCTRL->DmaCtrl[1] = 0x8 | (0x9<<4);
 
     min = 0;
@@ -2115,7 +2115,7 @@ uint32_t SYSCTRL_RC2MTune(uint32_t freq)
     if(Freq > freq){
         Freq = SYSCTRL_RC2MCalib(start);
     }
-    
+
     APB_PWM->Channels[0].Ctrl0 &= ~(0x1<<20);
     APB_PWM->PCAPChannels[0].Ctrl0 = 0;
     set_reg_bit((volatile uint32_t *)(APB_SYSCTRL_BASE + 0x70), 0, 0);

--- a/src/FWlib/peripheral_sysctrl.h
+++ b/src/FWlib/peripheral_sysctrl.h
@@ -1364,11 +1364,11 @@ void SYSCTRL_SelectKeyScanClk(SYSCTRL_ClkMode mode);
  *
  * Note: For SPI0: mode should be `SYSCTRL_CLK_SLOW`, or `SYSCTRL_CLK_PLL_DIV_1`, div should be in [1..15];
  *       For SPI1: mode should be `SYSCTRL_CLK_SLOW`, or `SYSCTRL_CLK_FAST_PER`, div is not used.
- * 
+ *
  * SOURCE_SLOW_CLK cannot set div if there are limitations using old interface.
  * if use old interface, mode should be `SYSCTRL_CLK_SLOW`, or `SYSCTRL_CLK_PLL_DIV_[1..15]`.
  */
-#define SYSCTRL_SelectSpiClk(port, mode) SYSCTRL_SelectSpiClkDiv(port, mode,1)    
+#define SYSCTRL_SelectSpiClk(port, mode) SYSCTRL_SelectSpiClkDiv(port, mode,1)
 void SYSCTRL_SelectSpiClkDiv(spi_port_t port, SYSCTRL_ClkMode mode, uint8_t div);
 
 /**
@@ -1770,13 +1770,13 @@ typedef enum
  */
 typedef enum
 {
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V200 = 0x3f, // 1.2V
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V300 = 0x35,
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V400 = 0x2a,
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V500 = 0x20,
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V600 = 0x15,
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V700 = 0xb,
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V800 = 0,// 1.8V
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V200 = 0x34, // 1.2V
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V300 = 0x22,
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V400 = 0x17,
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V500 = 0xf,
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V600 = 0x9,
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V700 = 0x4,
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V800 = 0x0,// 1.8V
 } SYSCTRL_BuckDCDCOutput;
 
 /**
@@ -1789,6 +1789,10 @@ typedef enum
  * The DCDC output range is 1.2 V to 1.8 V, adjustable in approximately 95 mV steps.
  * The enumeration (SYSCTRL_BuckDCDCOutput) lists typical values in 100 mV increments.
  * A trim value of zero corresponds to the maximum output voltage (1.8 V).
+ *
+ * @note
+ * Using this interface to adjust the DCDC power supply will affect the default dcdc
+ * voltage value configured by the "int Vcore_calib(void)" interface. about 1.42V.
  */
 void SYSCTRL_SetBuckDCDCOutput(SYSCTRL_BuckDCDCOutput level);
 
@@ -1797,7 +1801,9 @@ void SYSCTRL_SetBuckDCDCOutput(SYSCTRL_BuckDCDCOutput level);
  *
  * Default: Enabled.
  *
- * @param[in] enable        enable(1)/disable(0)
+ * .3
+ *
+ * @param[in] enable        enable(1)/disable(0)wsl
  */
 void SYSCTRL_EnableBuckDCDC(uint8_t enable);
 

--- a/src/FWlib/peripheral_sysctrl.h
+++ b/src/FWlib/peripheral_sysctrl.h
@@ -1,9 +1,9 @@
 #ifndef __PERIPHERAL_SYSCTRL_H__
 #define __PERIPHERAL_SYSCTRL_H__
 
-#ifdef	__cplusplus
-extern "C" {	/* allow C++ to use these headers */
-#endif	/* __cplusplus */
+#ifdef __cplusplus
+extern "C" { /* allow C++ to use these headers */
+#endif       /* __cplusplus */
 
 #include "ingsoc.h"
 #include "peripheral_pinctrl.h"
@@ -14,64 +14,64 @@ extern "C" {	/* allow C++ to use these headers */
 
 typedef enum
 {
-    SYSCTRL_ClkGate_APB_I2C0                =  4,
-    SYSCTRL_ClkGate_APB_SPI1                =  5,
-    SYSCTRL_ClkGate_APB_TMR0                =  6,
-    SYSCTRL_ClkGate_APB_TMR1                =  7,
-    SYSCTRL_ClkGate_APB_TMR2                =  8,
-    SYSCTRL_ClkGate_APB_UART0               =  9,
-    SYSCTRL_ClkGate_APB_UART1               = 10,
-    SYSCTRL_ClkGate_APB_GPIO                = 13,
-    SYSCTRL_ClkGate_APB_PWM                 = 16,
-    SYSCTRL_ClkGate_AHB_SPI0                = 17,
-    SYSCTRL_ClkGate_APB_PinCtrl             = 18,
-    SYSCTRL_ClkGate_APB_I2C1                = 19
+    SYSCTRL_ClkGate_APB_I2C0 = 4,
+    SYSCTRL_ClkGate_APB_SPI1 = 5,
+    SYSCTRL_ClkGate_APB_TMR0 = 6,
+    SYSCTRL_ClkGate_APB_TMR1 = 7,
+    SYSCTRL_ClkGate_APB_TMR2 = 8,
+    SYSCTRL_ClkGate_APB_UART0 = 9,
+    SYSCTRL_ClkGate_APB_UART1 = 10,
+    SYSCTRL_ClkGate_APB_GPIO = 13,
+    SYSCTRL_ClkGate_APB_PWM = 16,
+    SYSCTRL_ClkGate_AHB_SPI0 = 17,
+    SYSCTRL_ClkGate_APB_PinCtrl = 18,
+    SYSCTRL_ClkGate_APB_I2C1 = 19
 } SYSCTRL_ClkGateItem;
 
 // compatible definitions with ING916xx
-#define SYSCTRL_ClkGate_APB_GPIO0           SYSCTRL_ClkGate_APB_GPIO
-#define SYSCTRL_ClkGate_APB_GPIO1           SYSCTRL_ClkGate_APB_GPIO
-#define SYSCTRL_ClkGate_APB_WDT             SYSCTRL_ClkGate_APB_TMR0
+#define SYSCTRL_ClkGate_APB_GPIO0 SYSCTRL_ClkGate_APB_GPIO
+#define SYSCTRL_ClkGate_APB_GPIO1 SYSCTRL_ClkGate_APB_GPIO
+#define SYSCTRL_ClkGate_APB_WDT   SYSCTRL_ClkGate_APB_TMR0
 
 typedef enum
 {
-    SYSCTRL_Reset_AHB_LLE                 =  1,
-    SYSCTRL_Reset_AHB_IOC                 =  2,
-    SYSCTRL_Reset_APB_I2C0                =  3,
-    SYSCTRL_Reset_APB_SPI1                =  4,
-    SYSCTRL_Reset_APB_TMR0                =  5,
-    SYSCTRL_Reset_APB_TMR1                =  6,
-    SYSCTRL_Reset_APB_TMR2                =  7,
-    SYSCTRL_Reset_APB_SCI0                =  8,
-    SYSCTRL_Reset_APB_SCI1                =  9,
-    SYSCTRL_Reset_APB_ISOL                = 10,
-    SYSCTRL_Reset_RtcClk                  = 11,
-    SYSCTRL_Reset_APB_GPIOA               = 12,
-    SYSCTRL_Reset_APB_GPIOB               = 13,
-    SYSCTRL_Reset_APB_GPIOC               = 14,
-    SYSCTRL_Reset_APB_PWM                 = 15,
-    SYSCTRL_Reset_AHB_SPI0                = 16,
-    SYSCTRL_Reset_APB_PinCtrl             = 17,
-    SYSCTRL_Reset_APB_I2C1                = 18,
-    SYSCTRL_Reset_RF                      = 19,
-    SYSCTRL_Reset_LLE_RFCtrl              = 20,
-    SYSCTRL_Reset_APB_TRNG                = 21
+    SYSCTRL_Reset_AHB_LLE = 1,
+    SYSCTRL_Reset_AHB_IOC = 2,
+    SYSCTRL_Reset_APB_I2C0 = 3,
+    SYSCTRL_Reset_APB_SPI1 = 4,
+    SYSCTRL_Reset_APB_TMR0 = 5,
+    SYSCTRL_Reset_APB_TMR1 = 6,
+    SYSCTRL_Reset_APB_TMR2 = 7,
+    SYSCTRL_Reset_APB_SCI0 = 8,
+    SYSCTRL_Reset_APB_SCI1 = 9,
+    SYSCTRL_Reset_APB_ISOL = 10,
+    SYSCTRL_Reset_RtcClk = 11,
+    SYSCTRL_Reset_APB_GPIOA = 12,
+    SYSCTRL_Reset_APB_GPIOB = 13,
+    SYSCTRL_Reset_APB_GPIOC = 14,
+    SYSCTRL_Reset_APB_PWM = 15,
+    SYSCTRL_Reset_AHB_SPI0 = 16,
+    SYSCTRL_Reset_APB_PinCtrl = 17,
+    SYSCTRL_Reset_APB_I2C1 = 18,
+    SYSCTRL_Reset_RF = 19,
+    SYSCTRL_Reset_LLE_RFCtrl = 20,
+    SYSCTRL_Reset_APB_TRNG = 21
 } SYSCTRL_ResetItem;
 
 typedef enum
 {
-    SYSCTRL_LDO_OUPUT_1V60 = 0x13,  // Recommended for Vbat = 1.8V
-    SYSCTRL_LDO_OUPUT_1V80 = 0x16,  // Recommended for Vbat = 2.5V
-    SYSCTRL_LDO_OUPUT_2V50 = 0x1f,  // Recommended for Vbat = 3.3V
-}SYSCTRL_LDOOutputCore;
+    SYSCTRL_LDO_OUPUT_1V60 = 0x13, // Recommended for Vbat = 1.8V
+    SYSCTRL_LDO_OUPUT_1V80 = 0x16, // Recommended for Vbat = 2.5V
+    SYSCTRL_LDO_OUPUT_2V50 = 0x1f, // Recommended for Vbat = 3.3V
+} SYSCTRL_LDOOutputCore;
 
 enum
 {
-    SYSCTRL_BOR_0V85 = 0x06,        // BOR Vdd threshold = 0.85V
-    SYSCTRL_BOR_0V90 = 0x07,        // BOR Vdd threshold = 0.90V
-    SYSCTRL_BOR_0V95 = 0x08,        // BOR Vdd threshold = 0.95V
-    SYSCTRL_BOR_1V00 = 0x09,        // BOR Vdd threshold = 1.00V
-    SYSCTRL_BOR_1V05 = 0x0A,        // BOR Vdd threshold = 1.05V
+    SYSCTRL_BOR_0V85 = 0x06, // BOR Vdd threshold = 0.85V
+    SYSCTRL_BOR_0V90 = 0x07, // BOR Vdd threshold = 0.90V
+    SYSCTRL_BOR_0V95 = 0x08, // BOR Vdd threshold = 0.95V
+    SYSCTRL_BOR_1V00 = 0x09, // BOR Vdd threshold = 1.00V
+    SYSCTRL_BOR_1V05 = 0x0A, // BOR Vdd threshold = 1.05V
 };
 
 /**
@@ -90,26 +90,26 @@ uint32_t SYSCTRL_ReadClkGate(void);
  * @brief Reset/Release control of all components
  * @param data      Reset/Release control of each component
  */
-void SYSCTRL_WriteBlockRst(uint32_t data) ;
+void SYSCTRL_WriteBlockRst(uint32_t data);
 
 /**
  * @brief Get Reset/Release state of all components
  * @return Reset/Release state of each components
  */
-uint32_t SYSCTRL_ReadBlockRst(void) ;
+uint32_t SYSCTRL_ReadBlockRst(void);
 
 typedef enum
 {
-    SYSCTRL_MEM_BLOCK_0 = 0x20,     // block 0 is  8KiB starting from 0x20000000
-    SYSCTRL_MEM_BLOCK_1 = 0x40,     // block 1 is  8KiB following block 0
-    SYSCTRL_MEM_BLOCK_2 = 0x80,     // block 2 is 16KiB following block 1
-    SYSCTRL_MEM_BLOCK_3 = 0x100,    // block 3 is 16KiB following block 2
-    SYSCTRL_MEM_BLOCK_4 = 0x200,    // block 4 is 16KiB following block 3
-    SYSCTRL_SHARE_BLOCK_0 = 0x1,    // share memory block 0 is  8KiB starting from 0x400A0000
-    SYSCTRL_SHARE_BLOCK_1 = 0x2,    // share memory block 1 is  8KiB following block 0 (0x400A2000)
-    SYSCTRL_SHARE_BLOCK_2 = 0x4,    // share memory block 2 is 16KiB following block 1
-    SYSCTRL_SHARE_BLOCK_3 = 0x8,    // share memory block 3 is 16KiB following block 2
-    SYSCTRL_SHARE_BLOCK_4 = 0x10,   // share memory block 4 is 16KiB following block 3
+    SYSCTRL_MEM_BLOCK_0 = 0x20,   // block 0 is  8KiB starting from 0x20000000
+    SYSCTRL_MEM_BLOCK_1 = 0x40,   // block 1 is  8KiB following block 0
+    SYSCTRL_MEM_BLOCK_2 = 0x80,   // block 2 is 16KiB following block 1
+    SYSCTRL_MEM_BLOCK_3 = 0x100,  // block 3 is 16KiB following block 2
+    SYSCTRL_MEM_BLOCK_4 = 0x200,  // block 4 is 16KiB following block 3
+    SYSCTRL_SHARE_BLOCK_0 = 0x1,  // share memory block 0 is  8KiB starting from 0x400A0000
+    SYSCTRL_SHARE_BLOCK_1 = 0x2,  // share memory block 1 is  8KiB following block 0 (0x400A2000)
+    SYSCTRL_SHARE_BLOCK_2 = 0x4,  // share memory block 2 is 16KiB following block 1
+    SYSCTRL_SHARE_BLOCK_3 = 0x8,  // share memory block 3 is 16KiB following block 2
+    SYSCTRL_SHARE_BLOCK_4 = 0x10, // share memory block 4 is 16KiB following block 3
 } SYSCTRL_MemBlock;
 
 // these 3 blocks (16 + 8) KiB are reversed in _mini_bundles
@@ -122,14 +122,14 @@ typedef enum
  *
  * @return              clock in Hz
  */
-#define SYSCTRL_GetHClk()       48000000
+#define SYSCTRL_GetHClk() 48000000
 
-#define SYSCTRL_WAKEUP_SOURCE_AUTO          1       // waken up automatically by internal timer
-#define SYSCTRL_WAKEUP_SOURCE_EXT_INT       2       // waken up by EXT_INT
+#define SYSCTRL_WAKEUP_SOURCE_AUTO    1 // waken up automatically by internal timer
+#define SYSCTRL_WAKEUP_SOURCE_EXT_INT 2 // waken up by EXT_INT
 
 typedef struct
 {
-    uint32_t source;     // bit combination of `SYSCTRL_WAKEUP_SOURCE_...`
+    uint32_t source; // bit combination of `SYSCTRL_WAKEUP_SOURCE_...`
 } SYSCTRL_WakeupSource_t;
 
 /**
@@ -144,57 +144,57 @@ void SYSCTRL_PAEnable(void);
 
 typedef enum
 {
-    SYSCTRL_ITEM_APB_GPIO0     ,
-    SYSCTRL_ITEM_APB_GPIO1     ,
-    SYSCTRL_ITEM_APB_TMR0      ,
-    SYSCTRL_ITEM_APB_TMR1      ,
-    SYSCTRL_ITEM_APB_TMR2      ,
-    SYSCTRL_ITEM_APB_WDT       ,
-    SYSCTRL_ITEM_APB_PWM       ,
-    SYSCTRL_ITEM_APB_PDM       ,
-    SYSCTRL_ITEM_APB_QDEC      ,
-    SYSCTRL_ITEM_APB_KeyScan   ,
-    SYSCTRL_ITEM_APB_IR        ,
-    SYSCTRL_ITEM_APB_DMA       ,
-    SYSCTRL_ITEM_AHB_SPI0      ,
-    SYSCTRL_ITEM_APB_SPI1      ,
-    SYSCTRL_ITEM_APB_ADC       ,
-    SYSCTRL_ITEM_APB_I2S       ,
-    SYSCTRL_ITEM_APB_UART0     ,
-    SYSCTRL_ITEM_APB_UART1     ,
-    SYSCTRL_ITEM_APB_I2C0      ,
-    SYSCTRL_ITEM_APB_I2C1      ,
-    SYSCTRL_ITEM_APB_SysCtrl   ,
-    SYSCTRL_ITEM_APB_PinCtrl   ,
-    SYSCTRL_ITEM_APB_EFUSE     ,
-    SYSCTRL_ITEM_APB_USB       ,
-    SYSCTRL_ITEM_APB_LPC       ,
+    SYSCTRL_ITEM_APB_GPIO0,
+    SYSCTRL_ITEM_APB_GPIO1,
+    SYSCTRL_ITEM_APB_TMR0,
+    SYSCTRL_ITEM_APB_TMR1,
+    SYSCTRL_ITEM_APB_TMR2,
+    SYSCTRL_ITEM_APB_WDT,
+    SYSCTRL_ITEM_APB_PWM,
+    SYSCTRL_ITEM_APB_PDM,
+    SYSCTRL_ITEM_APB_QDEC,
+    SYSCTRL_ITEM_APB_KeyScan,
+    SYSCTRL_ITEM_APB_IR,
+    SYSCTRL_ITEM_APB_DMA,
+    SYSCTRL_ITEM_AHB_SPI0,
+    SYSCTRL_ITEM_APB_SPI1,
+    SYSCTRL_ITEM_APB_ADC,
+    SYSCTRL_ITEM_APB_I2S,
+    SYSCTRL_ITEM_APB_UART0,
+    SYSCTRL_ITEM_APB_UART1,
+    SYSCTRL_ITEM_APB_I2C0,
+    SYSCTRL_ITEM_APB_I2C1,
+    SYSCTRL_ITEM_APB_SysCtrl,
+    SYSCTRL_ITEM_APB_PinCtrl,
+    SYSCTRL_ITEM_APB_EFUSE,
+    SYSCTRL_ITEM_APB_USB,
+    SYSCTRL_ITEM_APB_LPC,
     SYSCTRL_ITEM_NUMBER,
 } SYSCTRL_Item;
 
 // compatible definitions with ING918xx
-#define  SYSCTRL_ClkGate_APB_GPIO0              SYSCTRL_ITEM_APB_GPIO0
-#define  SYSCTRL_ClkGate_APB_GPIO1              SYSCTRL_ITEM_APB_GPIO1
-#define  SYSCTRL_ClkGate_APB_TMR0               SYSCTRL_ITEM_APB_TMR0
-#define  SYSCTRL_ClkGate_APB_TMR1               SYSCTRL_ITEM_APB_TMR1
-#define  SYSCTRL_ClkGate_APB_TMR2               SYSCTRL_ITEM_APB_TMR2
-#define  SYSCTRL_ClkGate_APB_WDT                SYSCTRL_ITEM_APB_WDT
-#define  SYSCTRL_ClkGate_APB_PWM                SYSCTRL_ITEM_APB_PWM
-#define  SYSCTRL_ClkGate_APB_PDM                SYSCTRL_ITEM_APB_PDM
-#define  SYSCTRL_ClkGate_APB_QDEC               SYSCTRL_ITEM_APB_QDEC
-#define  SYSCTRL_ClkGate_APB_KeyScan            SYSCTRL_ITEM_APB_KeyScan
-#define  SYSCTRL_ClkGate_APB_IR                 SYSCTRL_ITEM_APB_IR
-#define  SYSCTRL_ClkGate_APB_DMA                SYSCTRL_ITEM_APB_DMA
-#define  SYSCTRL_ClkGate_AHB_SPI0               SYSCTRL_ITEM_AHB_SPI0
-#define  SYSCTRL_ClkGate_APB_SPI1               SYSCTRL_ITEM_APB_SPI1
-#define  SYSCTRL_ClkGate_APB_ADC                SYSCTRL_ITEM_APB_ADC
-#define  SYSCTRL_ClkGate_APB_I2S                SYSCTRL_ITEM_APB_I2S
-#define  SYSCTRL_ClkGate_APB_UART0              SYSCTRL_ITEM_APB_UART0
-#define  SYSCTRL_ClkGate_APB_UART1              SYSCTRL_ITEM_APB_UART1
-#define  SYSCTRL_ClkGate_APB_I2C0               SYSCTRL_ITEM_APB_I2C0
-#define  SYSCTRL_ClkGate_APB_I2C1               SYSCTRL_ITEM_APB_I2C1
-#define  SYSCTRL_ClkGate_APB_PinCtrl            SYSCTRL_ITEM_APB_PinCtrl
-#define  SYSCTRL_ClkGate_APB_EFUSE              SYSCTRL_ITEM_APB_EFUSE
+#define SYSCTRL_ClkGate_APB_GPIO0   SYSCTRL_ITEM_APB_GPIO0
+#define SYSCTRL_ClkGate_APB_GPIO1   SYSCTRL_ITEM_APB_GPIO1
+#define SYSCTRL_ClkGate_APB_TMR0    SYSCTRL_ITEM_APB_TMR0
+#define SYSCTRL_ClkGate_APB_TMR1    SYSCTRL_ITEM_APB_TMR1
+#define SYSCTRL_ClkGate_APB_TMR2    SYSCTRL_ITEM_APB_TMR2
+#define SYSCTRL_ClkGate_APB_WDT     SYSCTRL_ITEM_APB_WDT
+#define SYSCTRL_ClkGate_APB_PWM     SYSCTRL_ITEM_APB_PWM
+#define SYSCTRL_ClkGate_APB_PDM     SYSCTRL_ITEM_APB_PDM
+#define SYSCTRL_ClkGate_APB_QDEC    SYSCTRL_ITEM_APB_QDEC
+#define SYSCTRL_ClkGate_APB_KeyScan SYSCTRL_ITEM_APB_KeyScan
+#define SYSCTRL_ClkGate_APB_IR      SYSCTRL_ITEM_APB_IR
+#define SYSCTRL_ClkGate_APB_DMA     SYSCTRL_ITEM_APB_DMA
+#define SYSCTRL_ClkGate_AHB_SPI0    SYSCTRL_ITEM_AHB_SPI0
+#define SYSCTRL_ClkGate_APB_SPI1    SYSCTRL_ITEM_APB_SPI1
+#define SYSCTRL_ClkGate_APB_ADC     SYSCTRL_ITEM_APB_ADC
+#define SYSCTRL_ClkGate_APB_I2S     SYSCTRL_ITEM_APB_I2S
+#define SYSCTRL_ClkGate_APB_UART0   SYSCTRL_ITEM_APB_UART0
+#define SYSCTRL_ClkGate_APB_UART1   SYSCTRL_ITEM_APB_UART1
+#define SYSCTRL_ClkGate_APB_I2C0    SYSCTRL_ITEM_APB_I2C0
+#define SYSCTRL_ClkGate_APB_I2C1    SYSCTRL_ITEM_APB_I2C1
+#define SYSCTRL_ClkGate_APB_PinCtrl SYSCTRL_ITEM_APB_PinCtrl
+#define SYSCTRL_ClkGate_APB_EFUSE   SYSCTRL_ITEM_APB_EFUSE
 
 typedef SYSCTRL_Item SYSCTRL_ClkGateItem;
 
@@ -211,7 +211,7 @@ typedef SYSCTRL_Item SYSCTRL_ResetItem;
  */
 typedef enum
 {
-    SYSCTRL_LDO_OUTPUT_CORE_1V000 = 0,      // 1.000V
+    SYSCTRL_LDO_OUTPUT_CORE_1V000 = 0, // 1.000V
     SYSCTRL_LDO_OUTPUT_CORE_1V020 = 1,
     SYSCTRL_LDO_OUTPUT_CORE_1V040 = 2,
     SYSCTRL_LDO_OUTPUT_CORE_1V060 = 3,
@@ -240,7 +240,7 @@ typedef enum
  */
 typedef enum
 {
-    SYSCTRL_LDO_OUTPUT_FLASH_2V100 = 5,     // 2.100V
+    SYSCTRL_LDO_OUTPUT_FLASH_2V100 = 5, // 2.100V
     SYSCTRL_LDO_OUTPUT_FLASH_2V200 = 6,
     SYSCTRL_LDO_OUTPUT_FLASH_2V300 = 7,
     SYSCTRL_LDO_OUTPUT_FLASH_2V400 = 8,
@@ -282,16 +282,16 @@ enum
 
 typedef enum
 {
-    SYSCTRL_CLK_SLOW = 0,            // use slow clock
-    SYSCTRL_CLK_32k = 0,             // use 32kHz clock
-    SYSCTRL_CLK_HCLK = 1,            // use HCLK (same as MCU)
-    SYSCTRL_CLK_ADC_DIV = 1,         // use clock from ADC divider
+    SYSCTRL_CLK_SLOW = 0,    // use slow clock
+    SYSCTRL_CLK_32k = 0,     // use 32kHz clock
+    SYSCTRL_CLK_HCLK = 1,    // use HCLK (same as MCU)
+    SYSCTRL_CLK_ADC_DIV = 1, // use clock from ADC divider
 
-    SYSCTRL_CLK_PLL_DIV_1 = 1,       // use (PLL clock div 1)
-                                     // SYSCTRL_TMR_CLK_PLL_DIV_2: use (PLL clock div 2)
-                                     // ..
-                                     // SYSCTRL_TMR_CLK_PLL_DIV_15: use (PLL clock div 15)
-                                     // Feel free to cast [1..15] to SYSCTRL_ClkMode
+    SYSCTRL_CLK_PLL_DIV_1 = 1, // use (PLL clock div 1)
+                               // SYSCTRL_TMR_CLK_PLL_DIV_2: use (PLL clock div 2)
+                               // ..
+                               // SYSCTRL_TMR_CLK_PLL_DIV_15: use (PLL clock div 15)
+                               // Feel free to cast [1..15] to SYSCTRL_ClkMode
     SYSCTRL_CLK_PLL_DIV_2 = 2,
     SYSCTRL_CLK_PLL_DIV_3 = 3,
     SYSCTRL_CLK_PLL_DIV_4 = 4,
@@ -307,10 +307,10 @@ typedef enum
     SYSCTRL_CLK_PLL_DIV_14 = 14,
     SYSCTRL_CLK_PLL_DIV_15 = 15,
 
-    SYSCTRL_CLK_SLOW_DIV_1 = 1,      // use RF OSC clock div 1
-                                     // SYSCTRL_CLK_SLOW_DIV_2: use (RF OSC clock div 2)
-                                     // ..
-                                     // Feel free to cast [1..15] to SYSCTRL_ClkMode
+    SYSCTRL_CLK_SLOW_DIV_1 = 1, // use RF OSC clock div 1
+                                // SYSCTRL_CLK_SLOW_DIV_2: use (RF OSC clock div 2)
+                                // ..
+                                // Feel free to cast [1..15] to SYSCTRL_ClkMode
     SYSCTRL_CLK_SLOW_DIV_2 = 2,
     SYSCTRL_CLK_SLOW_DIV_3 = 3,
     SYSCTRL_CLK_SLOW_DIV_4 = 4,
@@ -593,10 +593,8 @@ int SYSCTRL_GetCLK32k(void);
  *                              after about 3 seconds. Developer are free to update
  *                              its configuration later.
  */
-void SYSCTRL_EnableConfigClocksAfterWakeup(uint8_t enable_pll, uint8_t pll_loop,
-        SYSCTRL_ClkMode hclk,
-        SYSCTRL_ClkMode flash_clk,
-        uint8_t enable_watchdog);
+void SYSCTRL_EnableConfigClocksAfterWakeup(uint8_t enable_pll, uint8_t pll_loop, SYSCTRL_ClkMode hclk,
+                                           SYSCTRL_ClkMode flash_clk, uint8_t enable_watchdog);
 
 /**
  * @brief Disable automatic configuration of core clocks after wakeup
@@ -610,8 +608,8 @@ void SYSCTRL_DisableConfigClocksAfterWakeup(void);
 
 typedef enum
 {
-    SYSCTRL_CPU_32k_CLK_32k = 0,    // use the clock configured by `SYSCTRL_SelectCLK32k`
-    SYSCTRL_CPU_32k_INTERNAL = 1,   // use the internal 32k clock source (32k OSC or 32k RC)
+    SYSCTRL_CPU_32k_CLK_32k = 0,  // use the clock configured by `SYSCTRL_SelectCLK32k`
+    SYSCTRL_CPU_32k_INTERNAL = 1, // use the internal 32k clock source (32k OSC or 32k RC)
 } SYSCTRL_CPU32kMode;
 
 /**
@@ -633,8 +631,8 @@ int SYSCTRL_GetCPU32k(void);
 
 typedef enum
 {
-    SYSCTRL_SLOW_RC_CLK = 0,        // RC clock (which is tunable)
-    SYSCTRL_SLOW_CLK_24M_RF = 1,    // 24MHz RF OSC clock (default)
+    SYSCTRL_SLOW_RC_CLK = 0,     // RC clock (which is tunable)
+    SYSCTRL_SLOW_CLK_24M_RF = 1, // 24MHz RF OSC clock (default)
 } SYSCTRL_SlowClkMode;
 
 /**
@@ -716,27 +714,27 @@ typedef enum
 {
     SYSCTRL_DMA_UART0_RX = 0,
     SYSCTRL_DMA_UART1_RX = 1,
-    SYSCTRL_DMA_SPI0_TX  = 2,
-    SYSCTRL_DMA_SPI1_TX  = 3,
-    SYSCTRL_DMA_I2C0     = 4,
-    SYSCTRL_DMA_QDEC0    = 5,
-    SYSCTRL_DMA_PWM1     = 6,
-    SYSCTRL_DMA_I2S_RX   = 7,
-    SYSCTRL_DMA_PDM      = 8,
-    SYSCTRL_DMA_ADC      = 9,
+    SYSCTRL_DMA_SPI0_TX = 2,
+    SYSCTRL_DMA_SPI1_TX = 3,
+    SYSCTRL_DMA_I2C0 = 4,
+    SYSCTRL_DMA_QDEC0 = 5,
+    SYSCTRL_DMA_PWM1 = 6,
+    SYSCTRL_DMA_I2S_RX = 7,
+    SYSCTRL_DMA_PDM = 8,
+    SYSCTRL_DMA_ADC = 9,
 
     SYSCTRL_DMA_UART0_TX = 0x10,
     SYSCTRL_DMA_UART1_TX = 0x11,
-    SYSCTRL_DMA_SPI0_RX  = 0x12,
-    SYSCTRL_DMA_SPI1_RX  = 0x13,
-    SYSCTRL_DMA_I2C1     = 0x14,
-    SYSCTRL_DMA_QDEC1    = 0x15,
-    SYSCTRL_DMA_KeyScan  = 0x16,
-    SYSCTRL_DMA_I2S_TX   = 0x17,
-    SYSCTRL_DMA_PWM0     = 0x18,
-    SYSCTRL_DMA_PWM2     = 0x19,
-    SYSCTRL_DMA_QDEC2    = 0x1A,
-    SYSCTRL_DMA_LAST     = SYSCTRL_DMA_QDEC2,
+    SYSCTRL_DMA_SPI0_RX = 0x12,
+    SYSCTRL_DMA_SPI1_RX = 0x13,
+    SYSCTRL_DMA_I2C1 = 0x14,
+    SYSCTRL_DMA_QDEC1 = 0x15,
+    SYSCTRL_DMA_KeyScan = 0x16,
+    SYSCTRL_DMA_I2S_TX = 0x17,
+    SYSCTRL_DMA_PWM0 = 0x18,
+    SYSCTRL_DMA_PWM2 = 0x19,
+    SYSCTRL_DMA_QDEC2 = 0x1A,
+    SYSCTRL_DMA_LAST = SYSCTRL_DMA_QDEC2,
 } SYSCTRL_DMA;
 
 /**
@@ -774,7 +772,7 @@ void SYSCTRL_SetLDOOutputFlash(SYSCTRL_LDOOutputFlash level);
  */
 typedef enum
 {
-    SYSCTRL_LDO_RF_OUTPUT_1V200 = 0,    // 1.200V
+    SYSCTRL_LDO_RF_OUTPUT_1V200 = 0, // 1.200V
     SYSCTRL_LDO_RF_OUTPUT_1V250 = 1,
     SYSCTRL_LDO_RF_OUTPUT_1V300 = 2,
     SYSCTRL_LDO_RF_OUTPUT_1V350 = 3,
@@ -824,7 +822,7 @@ void SYSCTRL_SetLDOOutputRF(SYSCTRL_LDOOutputRF level);
  */
 typedef enum
 {
-    SYSCTRL_ADC_VREF_1V2_OUTPUT_1V184 = 0,  // 1.184V
+    SYSCTRL_ADC_VREF_1V2_OUTPUT_1V184 = 0, // 1.184V
     SYSCTRL_ADC_VREF_1V2_OUTPUT_1V185 = 1,
     SYSCTRL_ADC_VREF_1V2_OUTPUT_1V186 = 2,
     SYSCTRL_ADC_VREF_1V2_OUTPUT_1V187 = 3,
@@ -962,14 +960,14 @@ void SYSCTRL_ClearPDRInt(void);
  */
 void SYSCTRL_USBPhyConfig(uint8_t enable, uint8_t pull_sel);
 
-#define SYSCTRL_WAKEUP_SOURCE_AUTO          1       // waken up automatically by internal timer
-#define SYSCTRL_WAKEUP_SOURCE_COMPARATOR    2       // waken up by comparator
-#define SYSCTRL_WAKEUP_SOURCE_RTC_ALARM     4       // waken up by RTC alarm
+#define SYSCTRL_WAKEUP_SOURCE_AUTO       1 // waken up automatically by internal timer
+#define SYSCTRL_WAKEUP_SOURCE_COMPARATOR 2 // waken up by comparator
+#define SYSCTRL_WAKEUP_SOURCE_RTC_ALARM  4 // waken up by RTC alarm
 
 typedef struct
 {
-    uint64_t gpio;      // if any GPIO (bit n for GPIO #n) has triggered wake up
-    uint32_t other;     // bit combination of `SYSCTRL_WAKEUP_SOURCE_...`
+    uint64_t gpio;  // if any GPIO (bit n for GPIO #n) has triggered wake up
+    uint32_t other; // bit combination of `SYSCTRL_WAKEUP_SOURCE_...`
 } SYSCTRL_WakeupSource_t;
 
 /**
@@ -1026,17 +1024,17 @@ typedef enum
     SYSCTRL_MEM_REMAPPABLE_BLOCK_1 = 0x04,
 
     // below definitions are kept for compatibility
-    SYSCTRL_MEM_BLOCK_0 = 0x10,     // block 0 is 16KiB starting from 0x20000000
-                                    // This block is always ON, and can't be turned off.
-    SYSCTRL_MEM_BLOCK_1 = 0x08,     // block 1 is 16KiB following block 0
+    SYSCTRL_MEM_BLOCK_0 = 0x10, // block 0 is 16KiB starting from 0x20000000
+                                // This block is always ON, and can't be turned off.
+    SYSCTRL_MEM_BLOCK_1 = 0x08, // block 1 is 16KiB following block 0
 
-    SYSCTRL_SHARE_BLOCK_0 = 0x01,   // share memory block 0 is  8KiB starting from 0x40120000
-    SYSCTRL_SHARE_BLOCK_1 = 0x02,   // share memory block 1 is 16KiB following block 2 (0x40124000)
-    SYSCTRL_SHARE_BLOCK_2 = 0x04,   // share memory block 2 is  8KiB following block 0 (0x40122000)
+    SYSCTRL_SHARE_BLOCK_0 = 0x01, // share memory block 0 is  8KiB starting from 0x40120000
+    SYSCTRL_SHARE_BLOCK_1 = 0x02, // share memory block 1 is 16KiB following block 2 (0x40124000)
+    SYSCTRL_SHARE_BLOCK_2 = 0x04, // share memory block 2 is  8KiB following block 0 (0x40122000)
 } SYSCTRL_MemBlock;
 
 // this blocks (16 + 8) KiB are reversed in _mini_bundles
-#define SYSCTRL_RESERVED_MEM_BLOCKS (SYSCTRL_SYS_MEM_BLOCK_0 | SYSCTRL_SYS_MEM_BLOCK_1 | SYSCTRL_SHARE_MEM_BLOCK_0)
+#define SYSCTRL_RESERVED_MEM_BLOCKS      (SYSCTRL_SYS_MEM_BLOCK_0 | SYSCTRL_SYS_MEM_BLOCK_1 | SYSCTRL_SHARE_MEM_BLOCK_0)
 
 typedef enum
 {
@@ -1093,56 +1091,56 @@ void SYSCTRL_ICacheFlush(void);
 
 typedef enum
 {
-    SYSCTRL_ITEM_APB_GPIO0     ,
-    SYSCTRL_ITEM_APB_GPIO1     ,
-    SYSCTRL_ITEM_APB_TMR0      ,
-    SYSCTRL_ITEM_APB_TMR1      ,
-    SYSCTRL_ITEM_APB_WDT       ,
-    SYSCTRL_ITEM_APB_PWM       ,
-    SYSCTRL_ITEM_APB_QDEC      ,
-    SYSCTRL_ITEM_APB_KeyScan   ,
-    SYSCTRL_ITEM_APB_DMA       ,
-    SYSCTRL_ITEM_AHB_SPI0      ,
-    SYSCTRL_ITEM_APB_SPI1      ,
-    SYSCTRL_ITEM_APB_ADC       ,
-    SYSCTRL_ITEM_APB_I2S       ,
-    SYSCTRL_ITEM_APB_UART0     ,
-    SYSCTRL_ITEM_APB_UART1     ,
-    SYSCTRL_ITEM_APB_I2C0      ,
-    SYSCTRL_ITEM_APB_SysCtrl   ,
-    SYSCTRL_ITEM_APB_PinCtrl   ,
-    SYSCTRL_ITEM_APB_USB       ,
-    SYSCTRL_ITEM_APB_ASDM       ,
-    SYSCTRL_ITEM_APB_RTIMER0    ,
-    SYSCTRL_ITEM_APB_RTIMER1    ,
-    SYSCTRL_ITEM_APB_PTE        ,
-    SYSCTRL_ITEM_APB_GPIOTE     ,
+    SYSCTRL_ITEM_APB_GPIO0,
+    SYSCTRL_ITEM_APB_GPIO1,
+    SYSCTRL_ITEM_APB_TMR0,
+    SYSCTRL_ITEM_APB_TMR1,
+    SYSCTRL_ITEM_APB_WDT,
+    SYSCTRL_ITEM_APB_PWM,
+    SYSCTRL_ITEM_APB_QDEC,
+    SYSCTRL_ITEM_APB_KeyScan,
+    SYSCTRL_ITEM_APB_DMA,
+    SYSCTRL_ITEM_AHB_SPI0,
+    SYSCTRL_ITEM_APB_SPI1,
+    SYSCTRL_ITEM_APB_ADC,
+    SYSCTRL_ITEM_APB_I2S,
+    SYSCTRL_ITEM_APB_UART0,
+    SYSCTRL_ITEM_APB_UART1,
+    SYSCTRL_ITEM_APB_I2C0,
+    SYSCTRL_ITEM_APB_SysCtrl,
+    SYSCTRL_ITEM_APB_PinCtrl,
+    SYSCTRL_ITEM_APB_USB,
+    SYSCTRL_ITEM_APB_ASDM,
+    SYSCTRL_ITEM_APB_RTIMER0,
+    SYSCTRL_ITEM_APB_RTIMER1,
+    SYSCTRL_ITEM_APB_PTE,
+    SYSCTRL_ITEM_APB_GPIOTE,
     SYSCTRL_ITEM_NUMBER,
 } SYSCTRL_Item;
 
 // compatible definitions with ING918xx
-#define  SYSCTRL_ClkGate_APB_GPIO0              SYSCTRL_ITEM_APB_GPIO0
-#define  SYSCTRL_ClkGate_APB_GPIO1              SYSCTRL_ITEM_APB_GPIO1
-#define  SYSCTRL_ClkGate_APB_TMR0               SYSCTRL_ITEM_APB_TMR0
-#define  SYSCTRL_ClkGate_APB_TMR1               SYSCTRL_ITEM_APB_TMR1
-#define  SYSCTRL_ClkGate_APB_WDT                SYSCTRL_ITEM_APB_WDT
-#define  SYSCTRL_ClkGate_APB_PWM                SYSCTRL_ITEM_APB_PWM
-#define  SYSCTRL_ClkGate_APB_QDEC               SYSCTRL_ITEM_APB_QDEC
-#define  SYSCTRL_ClkGate_APB_KeyScan            SYSCTRL_ITEM_APB_KeyScan
-#define  SYSCTRL_ClkGate_APB_DMA                SYSCTRL_ITEM_APB_DMA
-#define  SYSCTRL_ClkGate_AHB_SPI0               SYSCTRL_ITEM_AHB_SPI0
-#define  SYSCTRL_ClkGate_APB_SPI1               SYSCTRL_ITEM_APB_SPI1
-#define  SYSCTRL_ClkGate_APB_ADC                SYSCTRL_ITEM_APB_ADC
-#define  SYSCTRL_ClkGate_APB_I2S                SYSCTRL_ITEM_APB_I2S
-#define  SYSCTRL_ClkGate_APB_UART0              SYSCTRL_ITEM_APB_UART0
-#define  SYSCTRL_ClkGate_APB_UART1              SYSCTRL_ITEM_APB_UART1
-#define  SYSCTRL_ClkGate_APB_I2C0               SYSCTRL_ITEM_APB_I2C0
-#define  SYSCTRL_ClkGate_APB_PinCtrl            SYSCTRL_ITEM_APB_PinCtrl
-#define  SYSCTRL_ClkGate_APB_ASDM               SYSCTRL_ITEM_APB_ASDM
-#define  SYSCTRL_ClkGate_APB_RTIMER0            SYSCTRL_ITEM_APB_RTIMER0
-#define  SYSCTRL_ClkGate_APB_RTIMER1            SYSCTRL_ITEM_APB_RTIMER1
-#define  SYSCTRL_ClkGate_APB_PTE                SYSCTRL_ITEM_APB_PTE
-#define  SYSCTRL_ClkGate_APB_GPIOTE             SYSCTRL_ITEM_APB_GPIOTE
+#define SYSCTRL_ClkGate_APB_GPIO0        SYSCTRL_ITEM_APB_GPIO0
+#define SYSCTRL_ClkGate_APB_GPIO1        SYSCTRL_ITEM_APB_GPIO1
+#define SYSCTRL_ClkGate_APB_TMR0         SYSCTRL_ITEM_APB_TMR0
+#define SYSCTRL_ClkGate_APB_TMR1         SYSCTRL_ITEM_APB_TMR1
+#define SYSCTRL_ClkGate_APB_WDT          SYSCTRL_ITEM_APB_WDT
+#define SYSCTRL_ClkGate_APB_PWM          SYSCTRL_ITEM_APB_PWM
+#define SYSCTRL_ClkGate_APB_QDEC         SYSCTRL_ITEM_APB_QDEC
+#define SYSCTRL_ClkGate_APB_KeyScan      SYSCTRL_ITEM_APB_KeyScan
+#define SYSCTRL_ClkGate_APB_DMA          SYSCTRL_ITEM_APB_DMA
+#define SYSCTRL_ClkGate_AHB_SPI0         SYSCTRL_ITEM_AHB_SPI0
+#define SYSCTRL_ClkGate_APB_SPI1         SYSCTRL_ITEM_APB_SPI1
+#define SYSCTRL_ClkGate_APB_ADC          SYSCTRL_ITEM_APB_ADC
+#define SYSCTRL_ClkGate_APB_I2S          SYSCTRL_ITEM_APB_I2S
+#define SYSCTRL_ClkGate_APB_UART0        SYSCTRL_ITEM_APB_UART0
+#define SYSCTRL_ClkGate_APB_UART1        SYSCTRL_ITEM_APB_UART1
+#define SYSCTRL_ClkGate_APB_I2C0         SYSCTRL_ITEM_APB_I2C0
+#define SYSCTRL_ClkGate_APB_PinCtrl      SYSCTRL_ITEM_APB_PinCtrl
+#define SYSCTRL_ClkGate_APB_ASDM         SYSCTRL_ITEM_APB_ASDM
+#define SYSCTRL_ClkGate_APB_RTIMER0      SYSCTRL_ITEM_APB_RTIMER0
+#define SYSCTRL_ClkGate_APB_RTIMER1      SYSCTRL_ITEM_APB_RTIMER1
+#define SYSCTRL_ClkGate_APB_PTE          SYSCTRL_ITEM_APB_PTE
+#define SYSCTRL_ClkGate_APB_GPIOTE       SYSCTRL_ITEM_APB_GPIOTE
 
 typedef SYSCTRL_Item SYSCTRL_ClkGateItem;
 
@@ -1216,17 +1214,17 @@ typedef enum
 
 typedef enum
 {
-    SYSCTRL_CLK_SLOW = 0,            // use slow clock
-    SYSCTRL_CLK_32k = 0,             // use 32kHz clock
-    SYSCTRL_CLK_FAST_PER = 1,        // use fast peripheral clock
-    SYSCTRL_CLK_HCLK = 1,            // use HCLK (same as MCU)
-    SYSCTRL_CLK_ADC_DIV = 1,         // use clock from ADC divider
+    SYSCTRL_CLK_SLOW = 0,     // use slow clock
+    SYSCTRL_CLK_32k = 0,      // use 32kHz clock
+    SYSCTRL_CLK_FAST_PER = 1, // use fast peripheral clock
+    SYSCTRL_CLK_HCLK = 1,     // use HCLK (same as MCU)
+    SYSCTRL_CLK_ADC_DIV = 1,  // use clock from ADC divider
 
-    SYSCTRL_CLK_PLL_DIV_1 = 1,       // use (PLL clock div 1)
-                                     // SYSCTRL_TMR_CLK_PLL_DIV_2: use (PLL clock div 2)
-                                     // ..
-                                     // SYSCTRL_TMR_CLK_PLL_DIV_15: use (PLL clock div 15)
-                                     // Feel free to cast [1..15] to SYSCTRL_ClkMode
+    SYSCTRL_CLK_PLL_DIV_1 = 1, // use (PLL clock div 1)
+                               // SYSCTRL_TMR_CLK_PLL_DIV_2: use (PLL clock div 2)
+                               // ..
+                               // SYSCTRL_TMR_CLK_PLL_DIV_15: use (PLL clock div 15)
+                               // Feel free to cast [1..15] to SYSCTRL_ClkMode
     SYSCTRL_CLK_PLL_DIV_2 = 2,
     SYSCTRL_CLK_PLL_DIV_3 = 3,
     SYSCTRL_CLK_PLL_DIV_4 = 4,
@@ -1258,10 +1256,10 @@ typedef enum
     SYSCTRL_CLK_FAST_PER_DIV14 = 33,
     SYSCTRL_CLK_FAST_PER_DIV15 = 34,
 
-    SYSCTRL_CLK_SLOW_DIV_1 = 1,      // use RF OSC clock div 1
-                                     // SYSCTRL_CLK_SLOW_DIV_2: use (RF OSC clock div 2)
-                                     // ..
-                                     // Feel free to cast [1..15] to SYSCTRL_ClkMode
+    SYSCTRL_CLK_SLOW_DIV_1 = 1, // use RF OSC clock div 1
+                                // SYSCTRL_CLK_SLOW_DIV_2: use (RF OSC clock div 2)
+                                // ..
+                                // Feel free to cast [1..15] to SYSCTRL_ClkMode
     SYSCTRL_CLK_SLOW_DIV_2 = 2,
     SYSCTRL_CLK_SLOW_DIV_3 = 3,
     SYSCTRL_CLK_SLOW_DIV_4 = 4,
@@ -1303,8 +1301,8 @@ typedef enum
 
 typedef enum
 {
-    SYSCTRL_CPU_32k_CLK_EXT = 0,    // External 32K clock
-    SYSCTRL_CPU_32k_INTERNAL = 1,   // use the internal 32k clock source 32k RC
+    SYSCTRL_CPU_32k_CLK_EXT = 0,  // External 32K clock
+    SYSCTRL_CPU_32k_INTERNAL = 1, // use the internal 32k clock source 32k RC
 } SYSCTRL_CPU32kMode;
 
 /**
@@ -1368,7 +1366,7 @@ void SYSCTRL_SelectKeyScanClk(SYSCTRL_ClkMode mode);
  * SOURCE_SLOW_CLK cannot set div if there are limitations using old interface.
  * if use old interface, mode should be `SYSCTRL_CLK_SLOW`, or `SYSCTRL_CLK_PLL_DIV_[1..15]`.
  */
-#define SYSCTRL_SelectSpiClk(port, mode) SYSCTRL_SelectSpiClkDiv(port, mode,1)
+#define SYSCTRL_SelectSpiClk(port, mode) SYSCTRL_SelectSpiClkDiv(port, mode, 1)
 void SYSCTRL_SelectSpiClkDiv(spi_port_t port, SYSCTRL_ClkMode mode, uint8_t div);
 
 /**
@@ -1386,9 +1384,15 @@ void SYSCTRL_SelectUartClk(uart_port_t port, SYSCTRL_ClkMode mode);
  * SOURCE_SLOW_CLK cannot set div if there are limitations using old interface.
  * if use old interface, mode should be `SYSCTRL_CLK_SLOW`, or `SYSCTRL_CLK_PLL_DIV_[1..15]`.
  */
-#define SYSCTRL_SelectI2sClk(mode) \
-do { if (mode != SYSCTRL_CLK_SLOW) SYSCTRL_SelectI2sClkDiv(SOURCE_PLL_CLK, (uint8_t)mode); \
-    else SYSCTRL_SelectI2sClkDiv(SOURCE_SLOW_CLK, 1); } while (0)
+#define SYSCTRL_SelectI2sClk(mode)                                                                                     \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (mode != SYSCTRL_CLK_SLOW)                                                                                  \
+            SYSCTRL_SelectI2sClkDiv(SOURCE_PLL_CLK, (uint8_t)mode);                                                    \
+        else                                                                                                           \
+            SYSCTRL_SelectI2sClkDiv(SOURCE_SLOW_CLK, 1);                                                               \
+    }                                                                                                                  \
+    while (0)
 void SYSCTRL_SelectI2sClkDiv(pre_clk_source_t mode, uint8_t div);
 
 /**
@@ -1536,20 +1540,20 @@ void SYSCTRL_SelectQDECClk(SYSCTRL_ClkMode mode, uint16_t div);
 uint32_t SYSCTRL_GetCLK32k(void);
 
 // default PLL settings for automatic config after wakeup in boot loader
-#define PLL_BOOT_DEF_DIV_PRE        5
-#define PLL_BOOT_DEF_LOOP           70
-#define PLL_BOOT_DEF_DIV_OUTPUT     1
+#define PLL_BOOT_DEF_DIV_PRE    5
+#define PLL_BOOT_DEF_LOOP       70
+#define PLL_BOOT_DEF_DIV_OUTPUT 1
 
 // default hardware PLL settings when automatic config after wakeup in boot loader
 // is disabled
-#define PLL_HW_DEF_DIV_PRE          5
-#define PLL_HW_DEF_LOOP             80
-#define PLL_HW_DEF_DIV_OUTPUT       1
+#define PLL_HW_DEF_DIV_PRE      5
+#define PLL_HW_DEF_LOOP         80
+#define PLL_HW_DEF_DIV_OUTPUT   1
 
 typedef enum
 {
-    SYSCTRL_SLOW_RC_CLK = 0,        // RC clock (which is tunable)
-    SYSCTRL_SLOW_CLK_24M_RF = 1,    // 24MHz RF OSC clock (default)
+    SYSCTRL_SLOW_RC_CLK = 0,     // RC clock (which is tunable)
+    SYSCTRL_SLOW_CLK_24M_RF = 1, // 24MHz RF OSC clock (default)
 } SYSCTRL_SlowClkMode;
 
 /**
@@ -1682,7 +1686,7 @@ int SYSCTRL_GetDmaId(SYSCTRL_DMA item);
  */
 typedef enum
 {
-    SYSCTRL_LDO_RF_OUTPUT_1V200 = 0,    // 1.200V
+    SYSCTRL_LDO_RF_OUTPUT_1V200 = 0, // 1.200V
     SYSCTRL_LDO_RF_OUTPUT_1V250 = 1,
     SYSCTRL_LDO_RF_OUTPUT_1V300 = 2,
     SYSCTRL_LDO_RF_OUTPUT_1V350 = 3,
@@ -1725,7 +1729,7 @@ typedef enum
  */
 typedef enum
 {
-    SYSCTRL_ADC_VREF_1V2_OUTPUT_1V184 = 0,  // 1.184V
+    SYSCTRL_ADC_VREF_1V2_OUTPUT_1V184 = 0, // 1.184V
     SYSCTRL_ADC_VREF_1V2_OUTPUT_1V185 = 1,
     SYSCTRL_ADC_VREF_1V2_OUTPUT_1V186 = 2,
     SYSCTRL_ADC_VREF_1V2_OUTPUT_1V187 = 3,
@@ -1776,7 +1780,7 @@ typedef enum
     SYSCTRL_BUCK_DCDC_OUTPUT_1V500 = 0xf,
     SYSCTRL_BUCK_DCDC_OUTPUT_1V600 = 0x9,
     SYSCTRL_BUCK_DCDC_OUTPUT_1V700 = 0x4,
-    SYSCTRL_BUCK_DCDC_OUTPUT_1V800 = 0x0,// 1.8V
+    SYSCTRL_BUCK_DCDC_OUTPUT_1V800 = 0x0, // 1.8V
 } SYSCTRL_BuckDCDCOutput;
 
 /**
@@ -1910,12 +1914,12 @@ void SYSCTRL_ClearPDRInt(void);
  */
 void SYSCTRL_USBPhyConfig(uint8_t enable, uint8_t pull_sel);
 
-#define SYSCTRL_WAKEUP_SOURCE_AUTO          1       // waken up automatically by internal timer
+#define SYSCTRL_WAKEUP_SOURCE_AUTO 1 // waken up automatically by internal timer
 
 typedef struct
 {
-    uint64_t gpio;      // if any GPIO (bit n for GPIO #n) has triggered wake up
-    uint32_t other;     // bit combination of `SYSCTRL_WAKEUP_SOURCE_...`
+    uint64_t gpio;  // if any GPIO (bit n for GPIO #n) has triggered wake up
+    uint32_t other; // bit combination of `SYSCTRL_WAKEUP_SOURCE_...`
 } SYSCTRL_WakeupSource_t;
 
 /**
@@ -1982,7 +1986,8 @@ typedef enum
 } SYSCTRL_MemBlock;
 
 // this blocks (16 + 8) KiB are reversed in _mini_bundles
-#define SYSCTRL_RESERVED_MEM_BLOCKS (SYSCTRL_SYS_MEM_BLOCK_0 | SYSCTRL_SYS_MEM_BLOCK_1 | SYSCTRL_SHARE_MEM_BLOCK_0 | SYSCTRL_CACHE_BLOCK)
+#define SYSCTRL_RESERVED_MEM_BLOCKS                                                                                    \
+    (SYSCTRL_SYS_MEM_BLOCK_0 | SYSCTRL_SYS_MEM_BLOCK_1 | SYSCTRL_SHARE_MEM_BLOCK_0 | SYSCTRL_CACHE_BLOCK)
 
 typedef enum
 {
@@ -2168,7 +2173,7 @@ void SYSCTRL_ResetAllBlocks(void);
  */
 void SYSCTRL_ReleaseBlock(SYSCTRL_ResetItem item);
 
-#if(INGCHIPS_FAMILY != INGCHIPS_FAMILY_20)
+#if (INGCHIPS_FAMILY != INGCHIPS_FAMILY_20)
 /**
  * @brief Set LDO Core output level
  *
@@ -2303,6 +2308,6 @@ void SYSCTRL_Reset(void);
 
 #ifdef __cplusplus
 } /* allow C++ to use these headers */
-#endif	/* __cplusplus */
+#endif /* __cplusplus */
 
 #endif

--- a/src/Tools/rf_util.c
+++ b/src/Tools/rf_util.c
@@ -53,6 +53,8 @@ static const uint32_t rf_data[] = {
 #include "rf_powerboost_916.dat"
 };
 
+#define USE_DCDC_MODE 1
+
 static const int16_t power_mapping[] = {
 -6337, -2533, -1978, -1633, -1378, -1200, -1033, -941, -837, -733, -651, -573, \
 -498, -430, -372, -316, -261, -212, -167, -123, -78, -44, -12, 23, 57, \
@@ -65,7 +67,13 @@ void rf_enable_powerboost(void)
     platform_set_rf_init_data(rf_data);
     platform_set_rf_power_mapping(power_mapping);
 
+#if USE_DCDC_MODE
+    SYSCTRL_SetBuckDCDCOutput(SYSCTRL_BUCK_DCDC_OUTPUT_1V800);
+    SYSCTRL_EnableBuckDCDC(1);
+    SYSCTRL_EnableDCDCMode(1);
+#else
     SYSCTRL_EnableDCDCMode(0);
+#endif
 }
 
 #endif


### PR DESCRIPTION
Repair: The adc module adds default parameter calculation in the scenario of abnormal ft parameter, 
the dcdc mode voltage setting API updates the customized voltage setting, 
and the bost mode adds dcdc mode enable and voltage configuration.